### PR TITLE
PARQUET-1698: [C++] pre-buffer specified columns of row group

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -109,6 +109,7 @@ jobs:
       - name: Install Dependencies
         shell: bash
         run: |
+          brew update
           brew bundle --file=cpp/Brewfile
           brew bundle --file=c_glib/Brewfile
           bundle install --gemfile c_glib/Gemfile

--- a/ci/scripts/msys2_setup.sh
+++ b/ci/scripts/msys2_setup.sh
@@ -24,7 +24,8 @@ target=$1
 packages=()
 case "${target}" in
   cpp|c_glib|ruby)
-    packages+=(ccache)
+    # ccache may be broken on MinGW.
+    # packages+=(ccache)
     packages+=(${MINGW_PACKAGE_PREFIX}-boost)
     packages+=(${MINGW_PACKAGE_PREFIX}-brotli)
     packages+=(${MINGW_PACKAGE_PREFIX}-cmake)

--- a/ci/scripts/r_windows_build.sh
+++ b/ci/scripts/r_windows_build.sh
@@ -23,7 +23,8 @@ set -x
 # Make sure it is absolute and exported
 export ARROW_HOME="$(cd "${ARROW_HOME}" && pwd)"
 
-pacman --sync --noconfirm ccache
+# ccache may be broken on MinGW.
+# pacman --sync --noconfirm ccache
 
 wget https://raw.githubusercontent.com/r-windows/rtools-backports/master/pacman.conf
 cp -f pacman.conf /etc/pacman.conf

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -120,7 +120,7 @@ if(APPLE)
                       OUTPUT_STRIP_TRAILING_WHITESPACE)
     endif()
 
-    execute_process(COMMAND ${BREW_BIN} --prefix "llvm@${ARROW_CLANG_TOOLS_MAJOR_VERSION}"
+    execute_process(COMMAND ${BREW_BIN} --prefix "llvm@${ARROW_CLANG_TOOLS_VERSION_MAJOR}"
                     OUTPUT_VARIABLE CLANG_TOOLS_BREW_PREFIX
                     OUTPUT_STRIP_TRAILING_WHITESPACE)
     if(NOT CLANG_TOOLS_BREW_PREFIX)

--- a/cpp/src/arrow/array.cc
+++ b/cpp/src/arrow/array.cc
@@ -105,7 +105,11 @@ ArrayData ArrayData::Slice(int64_t off, int64_t len) const {
   auto copy = *this;
   copy.length = len;
   copy.offset = off;
-  copy.null_count = null_count != 0 ? kUnknownNullCount : 0;
+  if (null_count == length) {
+    copy.null_count = len;
+  } else {
+    copy.null_count = null_count != 0 ? kUnknownNullCount : 0;
+  }
   return copy;
 }
 

--- a/cpp/src/arrow/array_test.cc
+++ b/cpp/src/arrow/array_test.cc
@@ -79,6 +79,16 @@ TEST_F(TestArray, TestNullCount) {
   ASSERT_EQ(kUnknownNullCount, arr_default_null_count->data()->null_count);
 }
 
+TEST_F(TestArray, TestSlicePreservesAllNullCount) {
+  // These are placeholders
+  auto data = std::make_shared<Buffer>(nullptr, 0);
+  auto null_bitmap = std::make_shared<Buffer>(nullptr, 0);
+
+  Int32Array arr(/*length=*/100, data, null_bitmap,
+                 /*null_count*/ 100);
+  EXPECT_EQ(arr.Slice(1, 99)->data()->null_count, arr.Slice(1, 99)->length());
+}
+
 TEST_F(TestArray, TestLength) {
   // Placeholder buffer
   auto data = std::make_shared<Buffer>(nullptr, 0);

--- a/cpp/src/arrow/compute/kernels/cast.cc
+++ b/cpp/src/arrow/compute/kernels/cast.cc
@@ -1429,8 +1429,8 @@ Status GetListCastFunc(const DataType& in_type, std::shared_ptr<DataType> out_ty
                        const CastOptions& options,
                        std::unique_ptr<CastKernelBase>* kernel) {
   if (out_type->id() != TypeClass::type_id) {
-    // Kernel will be null
-    return Status::OK();
+    return Status::Invalid("Cannot cast from ", in_type.ToString(), " to ",
+                           out_type->ToString());
   }
   const DataType& in_value_type = *checked_cast<const TypeClass&>(in_type).value_type();
   std::shared_ptr<DataType> out_value_type =
@@ -1503,19 +1503,18 @@ Status GetCastFunction(const DataType& in_type, std::shared_ptr<DataType> out_ty
     CAST_FUNCTION_CASE(LargeStringType);
     CAST_FUNCTION_CASE(DictionaryType);
     case Type::NA:
-      cast_kernel.reset(new FromNullCastKernel(std::move(out_type)));
+      cast_kernel.reset(new FromNullCastKernel(out_type));
       break;
     case Type::LIST:
-      RETURN_NOT_OK(
-          GetListCastFunc<ListType>(in_type, std::move(out_type), options, &cast_kernel));
+      RETURN_NOT_OK(GetListCastFunc<ListType>(in_type, out_type, options, &cast_kernel));
       break;
     case Type::LARGE_LIST:
-      RETURN_NOT_OK(GetListCastFunc<LargeListType>(in_type, std::move(out_type), options,
-                                                   &cast_kernel));
+      RETURN_NOT_OK(
+          GetListCastFunc<LargeListType>(in_type, out_type, options, &cast_kernel));
       break;
     case Type::EXTENSION:
-      RETURN_NOT_OK(ExtensionCastKernel::Make(std::move(in_type), std::move(out_type),
-                                              options, &cast_kernel));
+      RETURN_NOT_OK(
+          ExtensionCastKernel::Make(std::move(in_type), out_type, options, &cast_kernel));
       break;
     default:
       break;

--- a/cpp/src/arrow/compute/kernels/cast_test.cc
+++ b/cpp/src/arrow/compute/kernels/cast_test.cc
@@ -1425,6 +1425,17 @@ TEST_F(TestCast, BooleanToString) { TestCastBooleanToString<StringType>(); }
 
 TEST_F(TestCast, BooleanToLargeString) { TestCastBooleanToString<LargeStringType>(); }
 
+TEST_F(TestCast, ListToPrimitive) {
+  auto from_int = ArrayFromJSON(list(int8()), "[[1, 2], [3, 4]]");
+  auto from_binary = ArrayFromJSON(list(binary()), "[[\"1\", \"2\"], [\"3\", \"4\"]]");
+
+  CastOptions options;
+  std::shared_ptr<Array> result;
+
+  ASSERT_RAISES(Invalid, Cast(&ctx_, *from_int, uint8(), options, &result));
+  ASSERT_RAISES(Invalid, Cast(&ctx_, *from_binary, utf8(), options, &result));
+}
+
 TEST_F(TestCast, ListToList) {
   CastOptions options;
   std::shared_ptr<Array> offsets;

--- a/cpp/src/arrow/dataset/file_base.cc
+++ b/cpp/src/arrow/dataset/file_base.cc
@@ -63,8 +63,8 @@ Result<std::shared_ptr<FileFragment>> FileFormat::MakeFragment(
 Result<std::shared_ptr<FileFragment>> FileFormat::MakeFragment(
     FileSource source, std::shared_ptr<ScanOptions> options,
     std::shared_ptr<Expression> partition_expression) {
-  return std::make_shared<FileFragment>(std::move(source), shared_from_this(), options,
-                                        std::move(partition_expression));
+  return std::shared_ptr<FileFragment>(new FileFragment(
+      std::move(source), shared_from_this(), options, std::move(partition_expression)));
 }
 
 Result<std::shared_ptr<WriteTask>> FileFormat::WriteFragment(

--- a/cpp/src/arrow/dataset/file_base.h
+++ b/cpp/src/arrow/dataset/file_base.h
@@ -162,19 +162,13 @@ class ARROW_DS_EXPORT FileFragment : public Fragment {
  public:
   Result<ScanTaskIterator> Scan(std::shared_ptr<ScanContext> context) override;
 
-  // XXX should this include format_->type_name?
-  std::string type_name() const override { return "file"; }
+  std::string type_name() const override { return format_->type_name(); }
   bool splittable() const override { return format_->splittable(); }
 
   const FileSource& source() const { return source_; }
   const std::shared_ptr<FileFormat>& format() const { return format_; }
 
-  FileFragment(FileSource source, std::shared_ptr<FileFormat> format,
-               std::shared_ptr<ScanOptions> scan_options)
-      : Fragment(std::move(scan_options)),
-        source_(std::move(source)),
-        format_(std::move(format)) {}
-
+ protected:
   FileFragment(FileSource source, std::shared_ptr<FileFormat> format,
                std::shared_ptr<ScanOptions> scan_options,
                std::shared_ptr<Expression> partition_expression)
@@ -182,7 +176,6 @@ class ARROW_DS_EXPORT FileFragment : public Fragment {
         source_(std::move(source)),
         format_(std::move(format)) {}
 
- protected:
   FileSource source_;
   std::shared_ptr<FileFormat> format_;
 

--- a/cpp/src/arrow/dataset/file_parquet.cc
+++ b/cpp/src/arrow/dataset/file_parquet.cc
@@ -183,26 +183,29 @@ class RowGroupSkipper {
 
   RowGroupSkipper(std::shared_ptr<parquet::FileMetaData> metadata,
                   parquet::ArrowReaderProperties arrow_properties,
-                  std::shared_ptr<Expression> filter)
+                  std::shared_ptr<Expression> filter, std::vector<int> row_groups)
       : metadata_(std::move(metadata)),
         arrow_properties_(std::move(arrow_properties)),
         filter_(std::move(filter)),
-        row_group_idx_(0) {
-    num_row_groups_ = metadata_->num_row_groups();
-  }
+        row_group_idx_(0),
+        row_groups_(std::move(row_groups)),
+        num_row_groups_(row_groups_.empty() ? metadata_->num_row_groups()
+                                            : static_cast<int>(row_groups_.size())) {}
 
   int Next() {
     while (row_group_idx_ < num_row_groups_) {
-      const auto row_group_idx = row_group_idx_++;
-      const auto row_group = metadata_->RowGroup(row_group_idx);
+      const int row_group =
+          row_groups_.empty() ? row_group_idx_++ : row_groups_[row_group_idx_++];
 
-      const auto num_rows = row_group->num_rows();
-      if (CanSkip(*row_group)) {
+      const auto row_group_metadata = metadata_->RowGroup(row_group);
+
+      const int64_t num_rows = row_group_metadata->num_rows();
+      if (CanSkip(*row_group_metadata)) {
         rows_skipped_ += num_rows;
         continue;
       }
 
-      return row_group_idx;
+      return row_group;
     }
 
     return kIterationDone;
@@ -225,6 +228,7 @@ class RowGroupSkipper {
   parquet::ArrowReaderProperties arrow_properties_;
   std::shared_ptr<Expression> filter_;
   int row_group_idx_;
+  std::vector<int> row_groups_;
   int num_row_groups_;
   int64_t rows_skipped_;
 };
@@ -234,7 +238,8 @@ class ParquetScanTaskIterator {
   static Result<ScanTaskIterator> Make(std::shared_ptr<ScanOptions> options,
                                        std::shared_ptr<ScanContext> context,
                                        std::unique_ptr<parquet::ParquetFileReader> reader,
-                                       parquet::ArrowReaderProperties arrow_properties) {
+                                       parquet::ArrowReaderProperties arrow_properties,
+                                       const std::vector<int>& row_groups) {
     auto metadata = reader->metadata();
 
     auto column_projection = InferColumnProjection(*metadata, arrow_properties, options);
@@ -244,7 +249,7 @@ class ParquetScanTaskIterator {
                                                    arrow_properties, &arrow_reader));
 
     RowGroupSkipper skipper(std::move(metadata), std::move(arrow_properties),
-                            options->filter);
+                            options->filter, row_groups);
 
     return ScanTaskIterator(ParquetScanTaskIterator(
         std::move(options), std::move(context), std::move(column_projection),
@@ -373,12 +378,86 @@ Result<std::shared_ptr<Schema>> ParquetFileFormat::Inspect(
 Result<ScanTaskIterator> ParquetFileFormat::ScanFile(
     const FileSource& source, std::shared_ptr<ScanOptions> options,
     std::shared_ptr<ScanContext> context) const {
+  return ScanFile(source, std::move(options), std::move(context), {});
+}
+
+Result<ScanTaskIterator> ParquetFileFormat::ScanFile(
+    const FileSource& source, std::shared_ptr<ScanOptions> options,
+    std::shared_ptr<ScanContext> context, const std::vector<int>& row_groups) const {
   auto properties = MakeReaderProperties(*this, context->pool);
   ARROW_ASSIGN_OR_RAISE(auto reader, OpenReader(source, std::move(properties)));
 
+  for (int i : row_groups) {
+    if (i >= reader->metadata()->num_row_groups()) {
+      return Status::IndexError("trying to scan row group ", i, " but ", source.path(),
+                                " only has ", reader->metadata()->num_row_groups(),
+                                " row groups");
+    }
+  }
+
   auto arrow_properties = MakeArrowReaderProperties(*this, options->batch_size, *reader);
   return ParquetScanTaskIterator::Make(std::move(options), std::move(context),
-                                       std::move(reader), std::move(arrow_properties));
+                                       std::move(reader), std::move(arrow_properties),
+                                       row_groups);
+}
+
+Result<std::shared_ptr<FileFragment>> ParquetFileFormat::MakeFragment(
+    FileSource source, std::shared_ptr<ScanOptions> options,
+    std::shared_ptr<Expression> partition_expression, std::vector<int> row_groups) {
+  return std::shared_ptr<FileFragment>(
+      new ParquetFileFragment(std::move(source), shared_from_this(), std::move(options),
+                              std::move(partition_expression), std::move(row_groups)));
+}
+
+Result<std::shared_ptr<FileFragment>> ParquetFileFormat::MakeFragment(
+    FileSource source, std::shared_ptr<ScanOptions> options,
+    std::shared_ptr<Expression> partition_expression) {
+  return std::shared_ptr<FileFragment>(
+      new ParquetFileFragment(std::move(source), shared_from_this(), std::move(options),
+                              std::move(partition_expression), {}));
+}
+
+Result<FragmentIterator> ParquetFileFormat::GetRowGroupFragments(
+    const ParquetFileFragment& fragment, std::shared_ptr<Expression> extra_filter) {
+  auto properties = MakeReaderProperties(*this);
+  ARROW_ASSIGN_OR_RAISE(auto reader,
+                        OpenReader(fragment.source(), std::move(properties)));
+
+  auto arrow_properties =
+      MakeArrowReaderProperties(*this, parquet::kArrowDefaultBatchSize, *reader);
+  auto metadata = reader->metadata();
+
+  auto row_groups = fragment.row_groups();
+  if (row_groups.empty()) {
+    row_groups = internal::Iota(metadata->num_row_groups());
+  }
+  FragmentVector fragments(row_groups.size());
+
+  auto new_options = std::make_shared<ScanOptions>(*fragment.scan_options());
+  if (!extra_filter->Equals(true)) {
+    new_options->filter = and_(std::move(extra_filter), std::move(new_options->filter));
+  }
+
+  RowGroupSkipper skipper(std::move(metadata), std::move(arrow_properties),
+                          new_options->filter, std::move(row_groups));
+
+  for (int i = 0, row_group = skipper.Next();
+       row_group != RowGroupSkipper::kIterationDone; row_group = skipper.Next()) {
+    ARROW_ASSIGN_OR_RAISE(fragments[i++],
+                          MakeFragment(fragment.source(), new_options,
+                                       fragment.partition_expression(), {row_group}));
+  }
+
+  return MakeVectorIterator(std::move(fragments));
+}
+
+Result<ScanTaskIterator> ParquetFileFragment::Scan(std::shared_ptr<ScanContext> context) {
+  return parquet_format().ScanFile(source_, scan_options_, std::move(context),
+                                   row_groups_);
+}
+
+const ParquetFileFormat& ParquetFileFragment::parquet_format() const {
+  return internal::checked_cast<const ParquetFileFormat&>(*format_);
 }
 
 }  // namespace dataset

--- a/cpp/src/arrow/dataset/filter.cc
+++ b/cpp/src/arrow/dataset/filter.cc
@@ -1260,5 +1260,7 @@ Result<std::shared_ptr<RecordBatch>> TreeEvaluator::Filter(
   return batch->Slice(0, 0);
 }
 
+std::shared_ptr<ScalarExpression> scalar(bool value) { return scalar(MakeScalar(value)); }
+
 }  // namespace dataset
 }  // namespace arrow

--- a/cpp/src/arrow/dataset/scanner.h
+++ b/cpp/src/arrow/dataset/scanner.h
@@ -114,6 +114,14 @@ class ARROW_DS_EXPORT ScanTask {
   const std::shared_ptr<ScanOptions>& options() const { return options_; }
   const std::shared_ptr<ScanContext>& context() const { return context_; }
 
+  /// \brief Convert a sequence of ScanTasks into a Table.
+  ///
+  /// Use this convenience utility with care. This will serially materialize the
+  /// Scan result in memory before creating the Table.
+  static Result<std::shared_ptr<Table>> ToTable(
+      const std::shared_ptr<ScanOptions>& options,
+      const std::shared_ptr<ScanContext>& context, ScanTaskIterator scan_tasks);
+
  protected:
   ScanTask(std::shared_ptr<ScanOptions> options, std::shared_ptr<ScanContext> context)
       : options_(std::move(options)), context_(std::move(context)) {}

--- a/cpp/src/arrow/dataset/test_util.h
+++ b/cpp/src/arrow/dataset/test_util.h
@@ -316,7 +316,7 @@ struct MakeFileSystemDatasetMixin {
 
 static const std::string& PathOf(const std::shared_ptr<Fragment>& fragment) {
   EXPECT_NE(fragment, nullptr);
-  EXPECT_EQ(fragment->type_name(), "file");
+  EXPECT_THAT(fragment->type_name(), "dummy");
   return internal::checked_cast<const FileFragment&>(*fragment).source().path();
 }
 

--- a/cpp/src/arrow/dataset/type_fwd.h
+++ b/cpp/src/arrow/dataset/type_fwd.h
@@ -53,6 +53,11 @@ class FileFormat;
 class FileFragment;
 class FileSystemDataset;
 
+class ParquetFileFormat;
+class ParquetFileFragment;
+
+class IpcFileFormat;
+
 class Expression;
 using ExpressionVector = std::vector<std::shared_ptr<Expression>>;
 
@@ -66,6 +71,10 @@ class CastExpression;
 class ScalarExpression;
 class FieldReferenceExpression;
 class ExpressionEvaluator;
+
+/// forward declared to facilitate scalar(true) as a default for Expression parameters
+ARROW_DS_EXPORT
+std::shared_ptr<ScalarExpression> scalar(bool);
 
 class Partitioning;
 class PartitioningFactory;

--- a/cpp/src/arrow/filesystem/filesystem.h
+++ b/cpp/src/arrow/filesystem/filesystem.h
@@ -156,7 +156,7 @@ struct ARROW_EXPORT FileSelector {
 };
 
 /// \brief Abstract file system API
-class ARROW_EXPORT FileSystem {
+class ARROW_EXPORT FileSystem : public std::enable_shared_from_this<FileSystem> {
  public:
   virtual ~FileSystem();
 

--- a/cpp/src/arrow/flight/client.cc
+++ b/cpp/src/arrow/flight/client.cc
@@ -325,10 +325,11 @@ Status GrpcStreamReader::Open(std::unique_ptr<ClientRpc> rpc,
                               std::unique_ptr<GrpcStreamReader>* out) {
   *out = std::unique_ptr<GrpcStreamReader>(new GrpcStreamReader);
   out->get()->rpc_ = std::move(rpc);
-  std::unique_ptr<GrpcIpcMessageReader> message_reader(
+  auto reader = std::unique_ptr<ipc::MessageReader>(
       new GrpcIpcMessageReader(out->get(), out->get()->rpc_, std::move(stream)));
-  return (ipc::RecordBatchStreamReader::Open(std::move(message_reader))
-              .Value(&(*out)->batch_reader_));
+  ARROW_ASSIGN_OR_RAISE((*out)->batch_reader_,
+                        ipc::RecordBatchStreamReader::Open(std::move(reader)));
+  return Status::OK();
 }
 
 std::shared_ptr<Schema> GrpcStreamReader::schema() const {

--- a/cpp/src/arrow/flight/internal.cc
+++ b/cpp/src/arrow/flight/internal.cc
@@ -89,7 +89,7 @@ static Status FromGrpcContext(const grpc::ClientContext& ctx, Status* status) {
   }
 
   const grpc::string_ref code_ref = (*code_val).second;
-  StatusCode code;
+  StatusCode code = {};
   RETURN_NOT_OK(StatusCodeFromString(code_ref, &code));
 
   const auto message_val = trailers.find(kGrpcStatusMessageHeader);

--- a/cpp/src/arrow/io/caching.h
+++ b/cpp/src/arrow/io/caching.h
@@ -27,6 +27,19 @@
 
 namespace arrow {
 namespace io {
+
+struct ARROW_EXPORT CacheOptions {
+  /// /brief The maximum distance in bytes between two consecutive
+  ///   ranges; beyond this value, ranges are not combined
+  int64_t hole_size_limit;
+  /// /brief The maximum size in bytes of a combined range; if
+  ///   combining two consecutive ranges would produce a range of a
+  ///   size greater than this, they are not combined
+  int64_t range_size_limit;
+
+  static CacheOptions Defaults();
+};
+
 namespace internal {
 
 /// \brief A read cache designed to hide IO latencies when reading.
@@ -40,16 +53,12 @@ class ARROW_EXPORT ReadRangeCache {
   static constexpr int64_t kDefaultHoleSizeLimit = 8192;
   static constexpr int64_t kDefaultRangeSizeLimit = 32 * 1024 * 1024;
 
-  /// Construct a read cache
-  ///
-  /// \param[in] hole_size_limit The maximum distance in bytes between two
-  ///   consecutive ranges; beyond this value, ranges are not combined
-  /// \param[in] range_size_limit The maximum size in bytes of a combined range;
-  ///   if combining two consecutive ranges would produce a range of a size
-  ///   greater than this, they are not combined
-  explicit ReadRangeCache(std::shared_ptr<RandomAccessFile> file,
-                          int64_t hole_size_limit = kDefaultHoleSizeLimit,
-                          int64_t range_size_limit = kDefaultRangeSizeLimit);
+  /// Construct a read cache with default
+  explicit ReadRangeCache(std::shared_ptr<RandomAccessFile> file)
+      : ReadRangeCache(file, CacheOptions::Defaults()) {}
+
+  /// Construct a read cache with given options
+  explicit ReadRangeCache(std::shared_ptr<RandomAccessFile> file, CacheOptions options);
   ~ReadRangeCache();
 
   /// \brief Cache the given ranges in the background.

--- a/cpp/src/arrow/io/memory_test.cc
+++ b/cpp/src/arrow/io/memory_test.cc
@@ -450,9 +450,10 @@ TEST(RangeReadCache, Basics) {
   std::string data = "abcdefghijklmnopqrstuvwxyz";
 
   auto file = std::make_shared<BufferReader>(Buffer(data));
-  const int64_t hole_size_limit = 2;
-  const int64_t range_size_limit = 10;
-  internal::ReadRangeCache cache(file, hole_size_limit, range_size_limit);
+  CacheOptions options = CacheOptions::Defaults();
+  options.hole_size_limit = 2;
+  options.range_size_limit = 10;
+  internal::ReadRangeCache cache(file, options);
 
   ASSERT_OK(cache.Cache({{1, 2}, {3, 2}, {8, 2}, {20, 2}, {25, 0}}));
   ASSERT_OK(cache.Cache({{10, 4}, {14, 0}, {15, 4}}));

--- a/cpp/src/arrow/util/bit_util.h
+++ b/cpp/src/arrow/util/bit_util.h
@@ -529,6 +529,8 @@ class BitmapReader {
     }
   }
 
+  int64_t position() const { return position_; }
+
  private:
   const uint8_t* bitmap_;
   int64_t position_;

--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -1979,7 +1979,8 @@ TEST(TestArrowReadWrite, ReadTableManually) {
   AssertTablesEqual(*actual, *expected, /*same_chunk_layout=*/false);
 }
 
-TEST(TestArrowReadWrite, GetRecordBatchReader) {
+void TestGetRecordBatchReader(
+    ReaderProperties parquet_properties = default_reader_properties()) {
   const int num_columns = 20;
   const int num_rows = 1000;
   const int batch_size = 100;
@@ -2031,6 +2032,15 @@ TEST(TestArrowReadWrite, GetRecordBatchReader) {
   ASSERT_EQ(nullptr, actual_batch);
 }
 
+TEST(TestArrowReadWrite, GetRecordBatchReader) { TestGetRecordBatchReader(); }
+
+// Same as the test above, but using coalesced reads.
+TEST(TestArrowReadWrite, CoalescedReads) {
+  ReaderProperties parquet_properties = default_reader_properties();
+  parquet_properties.enable_coalesced_stream();
+  TestGetRecordBatchReader(parquet_properties);
+}
+
 TEST(TestArrowReadWrite, ScanContents) {
   const int num_columns = 20;
   const int num_rows = 1000;
@@ -2077,6 +2087,45 @@ TEST(TestArrowReadWrite, ReadColumnSubset) {
   auto ex_schema = ::arrow::schema(ex_fields);
   auto expected = Table::Make(ex_schema, ex_columns);
   ASSERT_NO_FATAL_FAILURE(::arrow::AssertTablesEqual(*expected, *result));
+}
+
+TEST(TestArrowReadWrite, ReadCoalescedColumnSubset) {
+  const int num_columns = 20;
+  const int num_rows = 1000;
+
+  std::shared_ptr<Table> table;
+  ASSERT_NO_FATAL_FAILURE(MakeDoubleTable(num_columns, num_rows, 1, &table));
+  std::shared_ptr<Buffer> buffer;
+  ASSERT_NO_FATAL_FAILURE(WriteTableToBuffer(table, num_rows / 2,
+                                             default_arrow_writer_properties(), &buffer));
+
+  std::unique_ptr<FileReader> reader;
+  FileReaderBuilder builder;
+  ReaderProperties properties = default_reader_properties();
+  properties.enable_coalesced_stream();
+  ASSERT_OK(builder.Open(std::make_shared<BufferReader>(buffer), properties));
+  ASSERT_OK(builder.Build(&reader));
+  reader->set_use_threads(true);
+
+  // Test multiple subsets to ensure we can read from the file multiple times
+  std::vector<std::vector<int>> column_subsets = {
+      {0, 4, 8, 10}, {0, 1, 2, 3}, {5, 17, 18, 19}};
+
+  for (std::vector<int>& column_subset : column_subsets) {
+    std::shared_ptr<Table> result;
+    ASSERT_OK(reader->ReadTable(column_subset, &result));
+
+    std::vector<std::shared_ptr<::arrow::ChunkedArray>> ex_columns;
+    std::vector<std::shared_ptr<::arrow::Field>> ex_fields;
+    for (int i : column_subset) {
+      ex_columns.push_back(table->column(i));
+      ex_fields.push_back(table->field(i));
+    }
+
+    auto ex_schema = ::arrow::schema(ex_fields);
+    auto expected = Table::Make(ex_schema, ex_columns);
+    ASSERT_NO_FATAL_FAILURE(::arrow::AssertTablesEqual(*expected, *result));
+  }
 }
 
 TEST(TestArrowReadWrite, ListLargeRecords) {

--- a/cpp/src/parquet/arrow/writer.cc
+++ b/cpp/src/parquet/arrow/writer.cc
@@ -31,7 +31,9 @@
 #include "arrow/table.h"
 #include "arrow/type.h"
 #include "arrow/util/base64.h"
+#include "arrow/util/make_unique.h"
 #include "arrow/visitor_inline.h"
+#include "parquet/arrow/path_internal.h"
 #include "parquet/arrow/reader_internal.h"
 #include "parquet/arrow/schema.h"
 #include "parquet/column_writer.h"
@@ -44,6 +46,7 @@ using arrow::Array;
 using arrow::BinaryArray;
 using arrow::BooleanArray;
 using arrow::ChunkedArray;
+using arrow::DataType;
 using arrow::Decimal128Array;
 using arrow::DictionaryArray;
 using arrow::Field;
@@ -67,6 +70,32 @@ namespace parquet {
 namespace arrow {
 
 namespace {
+
+int CalculateLeafCount(const DataType& type) {
+  if (type.num_children() == 0) {
+    // Primitive type.
+    return 1;
+  }
+
+  int num_leaves = 0;
+  for (std::shared_ptr<Field> field : type.children()) {
+    num_leaves += CalculateLeafCount(*(field->type()));
+  }
+  return num_leaves;
+}
+
+// Determines if the |schema_field|'s root ancestor is nullable.
+bool HasNullableRoot(const SchemaManifest& schema_manifest,
+                     const SchemaField* schema_field) {
+  DCHECK(schema_field != nullptr);
+  const SchemaField* current_field = schema_field;
+  bool nullable = schema_field->field->nullable();
+  while (current_field != nullptr) {
+    nullable = current_field->field->nullable();
+    current_field = schema_manifest.GetParent(current_field);
+  }
+  return nullable;
+}
 
 class LevelBuilder {
  public:
@@ -311,6 +340,153 @@ Status GetLeafType(const ::arrow::DataType& type, ::arrow::Type::type* leaf_type
   }
 }
 
+// Manages writing nested parquet columns with support for all nested types
+// supported by parquet.
+class ArrowColumnWriterV2 {
+ public:
+  // Constructs a new object (use Make() method below to construct from
+  // A ChunkedArray).
+  // level_builders should contain one MultipathLevelBuilder per chunk of the
+  // Arrow-column to write.
+  ArrowColumnWriterV2(std::vector<std::unique_ptr<MultipathLevelBuilder>> level_builders,
+                      int leaf_count, RowGroupWriter* row_group_writer)
+      : level_builders_(std::move(level_builders)),
+        leaf_count_(leaf_count),
+        row_group_writer_(row_group_writer) {}
+
+  // Writes out all leaf parquet columns to the RowGroupWriter that this
+  // object was constructed with.  Each leaf column is written fully before
+  // the next column is written (i.e. no buffering is assumed).
+  //
+  // Columns are written in DFS order.
+  Status Write(ArrowWriteContext* ctx) {
+    for (int leaf_idx = 0; leaf_idx < leaf_count_; leaf_idx++) {
+      ColumnWriter* column_writer;
+      PARQUET_CATCH_NOT_OK(column_writer = row_group_writer_->NextColumn());
+      for (auto& level_builder : level_builders_) {
+        RETURN_NOT_OK(level_builder->Write(
+            leaf_idx, ctx, [&](const MultipathLevelBuilderResult& result) {
+              size_t visited_component_size = result.post_list_visited_elements.size();
+              DCHECK_GT(visited_component_size, 0);
+              if (visited_component_size != 1) {
+                return Status::NotImplemented(
+                    "Lists with non-zero length null components are not supported");
+              }
+              const ElementRange& range = result.post_list_visited_elements[0];
+              std::shared_ptr<Array> values_array =
+                  result.leaf_array->Slice(range.start, range.Size());
+
+              return column_writer->WriteArrow(result.def_levels, result.rep_levels,
+                                               result.def_rep_level_count, *values_array,
+                                               ctx);
+            }));
+      }
+
+      PARQUET_CATCH_NOT_OK(column_writer->Close());
+    }
+
+    return Status::OK();
+  }
+
+  // Make a new object by converting each chunk in |data| to a MultipathLevelBuilder.
+  //
+  // It is necessary to create a new builder per array because the MultipathlevelBuilder
+  // extracts the data necessary for writing each leaf column at construction time.
+  // (it optimizes based on null count) and with slicing via |offset| ephemeral
+  // chunks are created which need to be tracked across each leaf column-write.
+  // This decision could potentially be revisited if we wanted to use "buffered"
+  // RowGroupWriters (we could construct each builder on demand in that case).
+  static ::arrow::Result<std::unique_ptr<ArrowColumnWriterV2>> Make(
+      const ChunkedArray& data, int64_t offset, const int64_t size,
+      const SchemaManifest& schema_manifest, RowGroupWriter* row_group_writer) {
+    int64_t absolute_position = 0;
+    int chunk_index = 0;
+    int64_t chunk_offset = 0;
+    if (data.length() == 0) {
+      return ::arrow::internal::make_unique<ArrowColumnWriterV2>(
+          std::vector<std::unique_ptr<MultipathLevelBuilder>>{},
+          CalculateLeafCount(*data.type()), row_group_writer);
+    }
+    while (chunk_index < data.num_chunks() && absolute_position < offset) {
+      const int64_t chunk_length = data.chunk(chunk_index)->length();
+      if (absolute_position + chunk_length > offset) {
+        // Relative offset into the chunk to reach the desired start offset for
+        // writing
+        chunk_offset = offset - absolute_position;
+        break;
+      } else {
+        ++chunk_index;
+        absolute_position += chunk_length;
+      }
+    }
+
+    if (absolute_position >= data.length()) {
+      return Status::Invalid("Cannot write data at offset past end of chunked array");
+    }
+
+    int64_t values_written = 0;
+    std::vector<std::unique_ptr<MultipathLevelBuilder>> builders;
+    const int leaf_count = CalculateLeafCount(*data.type());
+    bool is_nullable;
+    // The row_group_writer hasn't been advanced yet so add 1 to the current
+    // which is the one this instance will start writing for.
+    int column_index = row_group_writer->current_column() + 1;
+    for (int leaf_offset = 0; leaf_offset < leaf_count; ++leaf_offset) {
+      const SchemaField* schema_field = nullptr;
+      RETURN_NOT_OK(
+          schema_manifest.GetColumnField(column_index + leaf_offset, &schema_field));
+      bool nullable_root = HasNullableRoot(schema_manifest, schema_field);
+      if (leaf_offset == 0) {
+        is_nullable = nullable_root;
+      }
+
+// Don't validate common ancestry for all leafs if not in debug.
+#ifndef NDEBUG
+      break;
+#else
+      if (is_nullable != nullable_root) {
+        return Status::UnknownError(
+            "Unexpected mismatched nullability between column index",
+            column_index + leaf_offset, " and ", column_index);
+      }
+#endif
+    }
+    while (values_written < size) {
+      const Array& chunk = *data.chunk(chunk_index);
+      const int64_t available_values = chunk.length() - chunk_offset;
+      const int64_t chunk_write_size = std::min(size - values_written, available_values);
+
+      // The chunk offset here will be 0 except for possibly the first chunk
+      // because of the advancing logic above
+      std::shared_ptr<Array> array_to_write = chunk.Slice(chunk_offset, chunk_write_size);
+
+      if (array_to_write->length() > 0) {
+        ARROW_ASSIGN_OR_RAISE(std::unique_ptr<MultipathLevelBuilder> builder,
+                              MultipathLevelBuilder::Make(*array_to_write, is_nullable));
+        if (leaf_count != builder->GetLeafCount()) {
+          return Status::UnknownError("data type leaf_count != builder_leaf_count",
+                                      leaf_count, " ", builder->GetLeafCount());
+        }
+        builders.emplace_back(std::move(builder));
+      }
+
+      if (chunk_write_size == available_values) {
+        chunk_offset = 0;
+        ++chunk_index;
+      }
+      values_written += chunk_write_size;
+    }
+    return ::arrow::internal::make_unique<ArrowColumnWriterV2>(
+        std::move(builders), leaf_count, row_group_writer);
+  }
+
+ private:
+  // One builder per column-chunk.
+  std::vector<std::unique_ptr<MultipathLevelBuilder>> level_builders_;
+  int leaf_count_;
+  RowGroupWriter* row_group_writer_;
+};
+
 class ArrowColumnWriter {
  public:
   ArrowColumnWriter(ArrowWriteContext* ctx, ColumnWriter* column_writer,
@@ -460,16 +636,26 @@ class FileWriterImpl : public FileWriter {
 
   Status WriteColumnChunk(const std::shared_ptr<ChunkedArray>& data, int64_t offset,
                           int64_t size) override {
-    ColumnWriter* column_writer;
-    PARQUET_CATCH_NOT_OK(column_writer = row_group_writer_->NextColumn());
+    if (arrow_properties_->engine_version() == ArrowWriterProperties::V1) {
+      ColumnWriter* column_writer;
+      PARQUET_CATCH_NOT_OK(column_writer = row_group_writer_->NextColumn());
 
-    const SchemaField* schema_field = nullptr;
-    RETURN_NOT_OK(schema_manifest_.GetColumnField(row_group_writer_->current_column(),
-                                                  &schema_field));
-    ArrowColumnWriter arrow_writer(&column_write_context_, column_writer, schema_field,
-                                   &schema_manifest_);
-    RETURN_NOT_OK(arrow_writer.Write(*data, offset, size));
-    return arrow_writer.Close();
+      const SchemaField* schema_field = nullptr;
+      RETURN_NOT_OK(schema_manifest_.GetColumnField(row_group_writer_->current_column(),
+                                                    &schema_field));
+
+      ArrowColumnWriter arrow_writer(&column_write_context_, column_writer, schema_field,
+                                     &schema_manifest_);
+      RETURN_NOT_OK(arrow_writer.Write(*data, offset, size));
+      return arrow_writer.Close();
+    } else if (arrow_properties_->engine_version() == ArrowWriterProperties::V2) {
+      ARROW_ASSIGN_OR_RAISE(
+          std::unique_ptr<ArrowColumnWriterV2> writer,
+          ArrowColumnWriterV2::Make(*data, offset, size, schema_manifest_,
+                                    row_group_writer_));
+      return writer->Write(&column_write_context_);
+    }
+    return Status::NotImplemented("Unknown engine version.");
   }
 
   Status WriteColumnChunk(const std::shared_ptr<::arrow::ChunkedArray>& data) override {

--- a/cpp/src/parquet/encoding.cc
+++ b/cpp/src/parquet/encoding.cc
@@ -1636,13 +1636,11 @@ void DictDecoderImpl<ByteArrayType>::SetDict(TypedDecoder<ByteArrayType>* dictio
   for (int i = 0; i < dictionary_length_; ++i) {
     total_size += dict_values[i].len;
   }
-  if (total_size > 0) {
-    PARQUET_THROW_NOT_OK(byte_array_data_->Resize(total_size,
-                                                  /*shrink_to_fit=*/false));
-    PARQUET_THROW_NOT_OK(
-        byte_array_offsets_->Resize((dictionary_length_ + 1) * sizeof(int32_t),
-                                    /*shrink_to_fit=*/false));
-  }
+  PARQUET_THROW_NOT_OK(byte_array_data_->Resize(total_size,
+                                                /*shrink_to_fit=*/false));
+  PARQUET_THROW_NOT_OK(
+      byte_array_offsets_->Resize((dictionary_length_ + 1) * sizeof(int32_t),
+                                  /*shrink_to_fit=*/false));
 
   int32_t offset = 0;
   uint8_t* bytes_data = byte_array_data_->mutable_data();

--- a/cpp/src/parquet/file_reader.cc
+++ b/cpp/src/parquet/file_reader.cc
@@ -25,6 +25,7 @@
 #include <string>
 #include <utility>
 
+#include "arrow/io/caching.h"
 #include "arrow/io/file.h"
 #include "arrow/util/logging.h"
 #include "arrow/util/ubsan.h"
@@ -78,14 +79,46 @@ std::unique_ptr<PageReader> RowGroupReader::GetColumnPageReader(int i) {
 // Returns the rowgroup metadata
 const RowGroupMetaData* RowGroupReader::metadata() const { return contents_->metadata(); }
 
+/// Compute the section of the file that should be read for the given
+/// row group and column chunk.
+arrow::io::ReadRange ComputeColumnChunkRange(FileMetaData* file_metadata,
+                                             int64_t source_size, int row_group_index,
+                                             int column_index) {
+  auto row_group_metadata = file_metadata->RowGroup(row_group_index);
+  auto column_metadata = row_group_metadata->ColumnChunk(column_index);
+
+  int64_t col_start = column_metadata->data_page_offset();
+  if (column_metadata->has_dictionary_page() &&
+      column_metadata->dictionary_page_offset() > 0 &&
+      col_start > column_metadata->dictionary_page_offset()) {
+    col_start = column_metadata->dictionary_page_offset();
+  }
+
+  int64_t col_length = column_metadata->total_compressed_size();
+  // PARQUET-816 workaround for old files created by older parquet-mr
+  const ApplicationVersion& version = file_metadata->writer_version();
+  if (version.VersionLt(ApplicationVersion::PARQUET_816_FIXED_VERSION())) {
+    // The Parquet MR writer had a bug in 1.2.8 and below where it didn't include the
+    // dictionary page header size in total_compressed_size and total_uncompressed_size
+    // (see IMPALA-694). We add padding to compensate.
+    int64_t bytes_remaining = source_size - (col_start + col_length);
+    int64_t padding = std::min<int64_t>(kMaxDictHeaderSize, bytes_remaining);
+    col_length += padding;
+  }
+
+  return {col_start, col_length};
+}
+
 // RowGroupReader::Contents implementation for the Parquet file specification
 class SerializedRowGroup : public RowGroupReader::Contents {
  public:
-  SerializedRowGroup(std::shared_ptr<ArrowInputFile> source, int64_t source_size,
-                     FileMetaData* file_metadata, int row_group_number,
-                     const ReaderProperties& props,
+  SerializedRowGroup(std::shared_ptr<ArrowInputFile> source,
+                     std::shared_ptr<::arrow::io::internal::ReadRangeCache> cached_source,
+                     int64_t source_size, FileMetaData* file_metadata,
+                     int row_group_number, const ReaderProperties& props,
                      std::shared_ptr<InternalFileDecryptor> file_decryptor = nullptr)
       : source_(std::move(source)),
+        cached_source_(cached_source ? std::move(cached_source) : nullptr),
         source_size_(source_size),
         file_metadata_(file_metadata),
         properties_(props),
@@ -102,27 +135,17 @@ class SerializedRowGroup : public RowGroupReader::Contents {
     // Read column chunk from the file
     auto col = row_group_metadata_->ColumnChunk(i);
 
-    int64_t col_start = col->data_page_offset();
-    if (col->has_dictionary_page() && col->dictionary_page_offset() > 0 &&
-        col_start > col->dictionary_page_offset()) {
-      col_start = col->dictionary_page_offset();
+    arrow::io::ReadRange col_range =
+        ComputeColumnChunkRange(file_metadata_, source_size_, row_group_ordinal_, i);
+    std::shared_ptr<ArrowInputStream> stream;
+    if (cached_source_) {
+      // PARQUET-1698: if read coalescing is enabled, read from pre-buffered
+      // segments.
+      PARQUET_ASSIGN_OR_THROW(auto buffer, cached_source_->Read(col_range));
+      stream = std::make_shared<::arrow::io::BufferReader>(buffer);
+    } else {
+      stream = properties_.GetStream(source_, col_range.offset, col_range.length);
     }
-
-    int64_t col_length = col->total_compressed_size();
-
-    // PARQUET-816 workaround for old files created by older parquet-mr
-    const ApplicationVersion& version = file_metadata_->writer_version();
-    if (version.VersionLt(ApplicationVersion::PARQUET_816_FIXED_VERSION())) {
-      // The Parquet MR writer had a bug in 1.2.8 and below where it didn't include the
-      // dictionary page header size in total_compressed_size and total_uncompressed_size
-      // (see IMPALA-694). We add padding to compensate.
-      int64_t bytes_remaining = source_size_ - (col_start + col_length);
-      int64_t padding = std::min<int64_t>(kMaxDictHeaderSize, bytes_remaining);
-      col_length += padding;
-    }
-
-    std::shared_ptr<ArrowInputStream> stream =
-        properties_.GetStream(source_, col_start, col_length);
 
     std::unique_ptr<ColumnCryptoMetaData> crypto_metadata = col->crypto_metadata();
 
@@ -166,6 +189,8 @@ class SerializedRowGroup : public RowGroupReader::Contents {
 
  private:
   std::shared_ptr<ArrowInputFile> source_;
+  // Will be nullptr if read coalescing is not enabled.
+  std::shared_ptr<::arrow::io::internal::ReadRangeCache> cached_source_;
   int64_t source_size_;
   FileMetaData* file_metadata_;
   std::unique_ptr<RowGroupMetaData> row_group_metadata_;
@@ -200,9 +225,9 @@ class SerializedFile : public ParquetFileReader::Contents {
   }
 
   std::shared_ptr<RowGroupReader> GetRowGroup(int i) override {
-    std::unique_ptr<SerializedRowGroup> contents(
-        new SerializedRowGroup(source_, source_size_, file_metadata_.get(),
-                               static_cast<int16_t>(i), properties_, file_decryptor_));
+    std::unique_ptr<SerializedRowGroup> contents(new SerializedRowGroup(
+        source_, cached_source_, source_size_, file_metadata_.get(),
+        static_cast<int16_t>(i), properties_, file_decryptor_));
     return std::make_shared<RowGroupReader>(std::move(contents));
   }
 
@@ -210,6 +235,23 @@ class SerializedFile : public ParquetFileReader::Contents {
 
   void set_metadata(std::shared_ptr<FileMetaData> metadata) {
     file_metadata_ = std::move(metadata);
+  }
+
+  void PreBuffer(const std::vector<int>& row_groups,
+                 const std::vector<int>& column_indices) {
+    if (!properties_.is_coalesced_stream_enabled()) {
+      return;
+    }
+    cached_source_ = std::make_shared<arrow::io::internal::ReadRangeCache>(
+        source_, properties_.coalescing_options());
+    std::vector<arrow::io::ReadRange> ranges;
+    for (int row : row_groups) {
+      for (int col : column_indices) {
+        ranges.push_back(
+            ComputeColumnChunkRange(file_metadata_.get(), source_size_, row, col));
+      }
+    }
+    PARQUET_THROW_NOT_OK(cached_source_->Cache(ranges));
   }
 
   void ParseMetaData() {
@@ -263,6 +305,7 @@ class SerializedFile : public ParquetFileReader::Contents {
 
  private:
   std::shared_ptr<ArrowInputFile> source_;
+  std::shared_ptr<arrow::io::internal::ReadRangeCache> cached_source_;
   int64_t source_size_;
   std::shared_ptr<FileMetaData> file_metadata_;
   ReaderProperties properties_;
@@ -534,6 +577,13 @@ std::shared_ptr<RowGroupReader> ParquetFileReader::RowGroup(int i) {
       << "row groups, requested reader for: " << i;
 
   return contents_->GetRowGroup(i);
+}
+
+void ParquetFileReader::PreBuffer(const std::vector<int>& row_groups,
+                                  const std::vector<int>& column_indices) {
+  // Access private methods here
+  SerializedFile* file = static_cast<SerializedFile*>(contents_.get());
+  file->PreBuffer(row_groups, column_indices);
 }
 
 // ----------------------------------------------------------------------

--- a/cpp/src/parquet/file_reader.h
+++ b/cpp/src/parquet/file_reader.h
@@ -117,6 +117,15 @@ class PARQUET_EXPORT ParquetFileReader {
   // Returns the file metadata. Only one instance is ever created
   std::shared_ptr<FileMetaData> metadata() const;
 
+  /// Pre-buffer the specified column indices in all row groups.
+  ///
+  /// Only has an effect if ReaderProperties.is_coalesced_stream_enabled is set;
+  /// otherwise this is a no-op. The reader internally maintains a cache which is
+  /// overwritten each time this is called. Intended to increase performance on
+  /// high-latency filesystems (e.g. Amazon S3).
+  void PreBuffer(const std::vector<int>& row_groups,
+                 const std::vector<int>& column_indices);
+
  private:
   // Holds a pointer to an instance of Contents implementation
   std::unique_ptr<Contents> contents_;

--- a/cpp/src/parquet/file_writer.h
+++ b/cpp/src/parquet/file_writer.h
@@ -69,7 +69,8 @@ class PARQUET_EXPORT RowGroupWriter {
   /// directly written to the sink, once a new column is started, the contents
   /// of the previous one cannot be modified anymore.
   ColumnWriter* NextColumn();
-  /// Index of currently written column
+  /// Index of currently written column. Equal to -1 if NextColumn()
+  /// has not been called yet.
   int current_column();
   void Close();
 

--- a/cpp/src/parquet/properties.h
+++ b/cpp/src/parquet/properties.h
@@ -23,6 +23,7 @@
 #include <unordered_set>
 #include <utility>
 
+#include "arrow/io/caching.h"
 #include "arrow/type.h"
 #include "arrow/util/compression.h"
 #include "parquet/encryption.h"
@@ -40,13 +41,16 @@ struct ParquetVersion {
 
 static int64_t DEFAULT_BUFFER_SIZE = 1024;
 static bool DEFAULT_USE_BUFFERED_STREAM = false;
+static bool DEFAULT_USE_COALESCED_STREAM = false;
 
 class PARQUET_EXPORT ReaderProperties {
  public:
   explicit ReaderProperties(MemoryPool* pool = ::arrow::default_memory_pool())
       : pool_(pool) {
     buffered_stream_enabled_ = DEFAULT_USE_BUFFERED_STREAM;
+    coalesced_stream_enabled_ = DEFAULT_USE_COALESCED_STREAM;
     buffer_size_ = DEFAULT_BUFFER_SIZE;
+    coalescing_options_ = ::arrow::io::CacheOptions::Defaults();
   }
 
   MemoryPool* memory_pool() const { return pool_; }
@@ -56,9 +60,31 @@ class PARQUET_EXPORT ReaderProperties {
 
   bool is_buffered_stream_enabled() const { return buffered_stream_enabled_; }
 
+  bool is_coalesced_stream_enabled() const { return coalesced_stream_enabled_; }
+
   void enable_buffered_stream() { buffered_stream_enabled_ = true; }
 
   void disable_buffered_stream() { buffered_stream_enabled_ = false; }
+
+  /// Enable read coalescing.
+  ///
+  /// When enabled, readers can optionally call
+  /// ParquetFileReader.PreBuffer to cache the necessary slices of the
+  /// file in-memory before deserialization. Arrow readers
+  /// automatically do this. This is intended to increase performance
+  /// when reading from high-latency filesystems (e.g. Amazon S3).
+  ///
+  /// When this is enabled, it is NOT SAFE to concurrently create
+  /// RecordBatchReaders from the same file.
+  void enable_coalesced_stream() { coalesced_stream_enabled_ = true; }
+
+  void disable_coalesced_stream() { coalesced_stream_enabled_ = false; }
+
+  void coalescing_options(::arrow::io::CacheOptions options) {
+    coalescing_options_ = options;
+  }
+
+  ::arrow::io::CacheOptions coalescing_options() const { return coalescing_options_; }
 
   void set_buffer_size(int64_t buf_size) { buffer_size_ = buf_size; }
 
@@ -76,7 +102,9 @@ class PARQUET_EXPORT ReaderProperties {
   MemoryPool* pool_;
   int64_t buffer_size_;
   bool buffered_stream_enabled_;
+  bool coalesced_stream_enabled_;
   std::shared_ptr<FileDecryptionProperties> file_decryption_properties_;
+  ::arrow::io::CacheOptions coalescing_options_;
 };
 
 ReaderProperties PARQUET_EXPORT default_reader_properties();

--- a/java/vector/src/main/codegen/templates/UnionVector.java
+++ b/java/vector/src/main/codegen/templates/UnionVector.java
@@ -482,10 +482,8 @@ public class UnionVector implements FieldVector {
 
     @Override
     public void splitAndTransfer(int startIndex, int length) {
-      Preconditions.checkArgument(startIndex >= 0 && startIndex < valueCount,
-          "Invalid startIndex: %s", startIndex);
-      Preconditions.checkArgument(startIndex + length <= valueCount,
-          "Invalid length: %s", length);
+      Preconditions.checkArgument(startIndex >= 0 && length >= 0 && startIndex + length <= valueCount,
+          "Invalid parameters startIndex: %s, length: %s for valueCount: %s", startIndex, length, valueCount);
       to.clear();
       internalStructVectorTransferPair.splitAndTransfer(startIndex, length);
       final int startPoint = startIndex * TYPE_WIDTH;

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseFixedWidthVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseFixedWidthVector.java
@@ -584,10 +584,8 @@ public abstract class BaseFixedWidthVector extends BaseValueVector
    */
   public void splitAndTransferTo(int startIndex, int length,
                                  BaseFixedWidthVector target) {
-    Preconditions.checkArgument(startIndex >= 0 && startIndex < valueCount,
-        "Invalid startIndex: %s", startIndex);
-    Preconditions.checkArgument(startIndex + length <= valueCount,
-        "Invalid length: %s", length);
+    Preconditions.checkArgument(startIndex >= 0 && length >= 0 && startIndex + length <= valueCount,
+        "Invalid parameters startIndex: %s, length: %s for valueCount: %s", startIndex, length, valueCount);
     compareTypes(target, "splitAndTransferTo");
     target.clear();
     splitAndTransferValidityBuffer(startIndex, length, target);

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthVector.java
@@ -714,10 +714,8 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
    */
   public void splitAndTransferTo(int startIndex, int length,
                                  BaseVariableWidthVector target) {
-    Preconditions.checkArgument(startIndex >= 0 && startIndex < valueCount,
-        "Invalid startIndex: %s", startIndex);
-    Preconditions.checkArgument(startIndex + length <= valueCount,
-        "Invalid length: %s", length);
+    Preconditions.checkArgument(startIndex >= 0 && length >= 0 && startIndex + length <= valueCount,
+        "Invalid parameters startIndex: %s, length: %s for valueCount: %s", startIndex, length, valueCount);
     compareTypes(target, "splitAndTransferTo");
     target.clear();
     splitAndTransferValidityBuffer(startIndex, length, target);

--- a/java/vector/src/main/java/org/apache/arrow/vector/BitVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BitVector.java
@@ -164,10 +164,8 @@ public final class BitVector extends BaseFixedWidthVector {
    * @param target     destination vector
    */
   public void splitAndTransferTo(int startIndex, int length, BaseFixedWidthVector target) {
-    Preconditions.checkArgument(startIndex >= 0 && startIndex < valueCount,
-        "Invalid startIndex: %s", startIndex);
-    Preconditions.checkArgument(startIndex + length <= valueCount,
-        "Invalid length: %s", length);
+    Preconditions.checkArgument(startIndex >= 0 && length >= 0 && startIndex + length <= valueCount,
+        "Invalid parameters startIndex: %s, length: %s for valueCount: %s", startIndex, length, valueCount);
     compareTypes(target, "splitAndTransferTo");
     target.clear();
     target.validityBuffer = splitAndTransferBuffer(startIndex, length, target,

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/FixedSizeListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/FixedSizeListVector.java
@@ -590,10 +590,8 @@ public class FixedSizeListVector extends BaseValueVector implements BaseListVect
 
     @Override
     public void splitAndTransfer(int startIndex, int length) {
-      Preconditions.checkArgument(startIndex >= 0 && startIndex < valueCount,
-          "Invalid startIndex: %s", startIndex);
-      Preconditions.checkArgument(startIndex + length <= valueCount,
-          "Invalid length: %s", length);
+      Preconditions.checkArgument(startIndex >= 0 && length >= 0 && startIndex + length <= valueCount,
+          "Invalid parameters startIndex: %s, length: %s for valueCount: %s", startIndex, length, valueCount);
       final int startPoint = listSize * startIndex;
       final int sliceLength = listSize * length;
       to.clear();

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
@@ -493,10 +493,8 @@ public class ListVector extends BaseRepeatedValueVector implements PromotableVec
      */
     @Override
     public void splitAndTransfer(int startIndex, int length) {
-      Preconditions.checkArgument(startIndex >= 0 && startIndex < valueCount,
-          "Invalid startIndex: %s", startIndex);
-      Preconditions.checkArgument(startIndex + length <= valueCount,
-          "Invalid length: %s", length);
+      Preconditions.checkArgument(startIndex >= 0 && length >= 0 && startIndex + length <= valueCount,
+          "Invalid parameters startIndex: %s, length: %s for valueCount: %s", startIndex, length, valueCount);
       final int startPoint = offsetBuffer.getInt(startIndex * OFFSET_WIDTH);
       final int sliceLength = offsetBuffer.getInt((startIndex + length) * OFFSET_WIDTH) - startPoint;
       to.clear();

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/StructVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/StructVector.java
@@ -195,10 +195,8 @@ public class StructVector extends NonNullableStructVector implements FieldVector
 
     @Override
     public void splitAndTransfer(int startIndex, int length) {
-      Preconditions.checkArgument(startIndex >= 0 && startIndex < valueCount,
-          "Invalid startIndex: %s", startIndex);
-      Preconditions.checkArgument(startIndex + length <= valueCount,
-          "Invalid length: %s", length);
+      Preconditions.checkArgument(startIndex >= 0 && length >= 0 && startIndex + length <= valueCount,
+          "Invalid parameters startIndex: %s, length: %s for valueCount: %s", startIndex, length, valueCount);
       target.clear();
       splitAndTransferValidityBuffer(startIndex, length, target);
       super.splitAndTransfer(startIndex, length);

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -27,8 +27,6 @@ from pyarrow.lib cimport *
 from pyarrow.includes.libarrow_dataset cimport *
 from pyarrow.compat import frombytes, tobytes
 from pyarrow._fs cimport FileSystem, FileInfo, FileSelector
-from pyarrow.types import (is_null, is_boolean, is_integer, is_floating,
-                           is_string)
 
 
 def _forbid_instantiation(klass, subclasses_instead=True):
@@ -336,6 +334,11 @@ cdef class FileSystemDataset(Dataset):
         return FileFormat.wrap(self.filesystem_dataset.format())
 
 
+def _empty_dataset_scanner(Schema schema not None, columns=None, filter=None):
+    dataset = UnionDataset(schema, children=[])
+    return Scanner(dataset, columns=columns, filter=filter)
+
+
 cdef class FileFormat:
 
     cdef:
@@ -367,6 +370,35 @@ cdef class FileFormat:
     cdef inline shared_ptr[CFileFormat] unwrap(self):
         return self.wrapped
 
+    def inspect(self, str path not None, FileSystem filesystem not None):
+        cdef:
+            shared_ptr[CSchema] c_schema
+
+        c_schema = GetResultValue(self.format.Inspect(CFileSource(
+            tobytes(path), filesystem.unwrap().get())))
+        return pyarrow_wrap_schema(move(c_schema))
+
+    def make_fragment(self, str path not None, FileSystem filesystem not None,
+                      Schema schema=None, columns=None, filter=None,
+                      Expression partition_expression=ScalarExpression(True)):
+        cdef:
+            shared_ptr[CScanOptions] c_options
+            shared_ptr[CFileFragment] c_fragment
+            Scanner scanner
+
+        if schema is None:
+            schema = self.inspect(path, filesystem)
+
+        scanner = _empty_dataset_scanner(schema, columns, filter)
+        c_options = scanner.unwrap().get().options()
+
+        c_fragment = GetResultValue(
+            self.format.MakeFragment(CFileSource(tobytes(path),
+                                                 filesystem.unwrap().get()),
+                                     move(c_options),
+                                     partition_expression.unwrap()))
+        return Fragment.wrap(<shared_ptr[CFragment]> move(c_fragment))
+
 
 cdef class Fragment:
     """Fragment of data from a Dataset."""
@@ -386,8 +418,12 @@ cdef class Fragment:
         cdef Fragment self = Fragment()
 
         typ = frombytes(sp.get().type_name())
-        if typ == 'file':
+        if typ == 'ipc':
+            # IpcFileFormat does not have a corresponding subclass
+            # of FileFragment
             self = FileFragment.__new__(FileFragment)
+        elif typ == 'parquet':
+            self = ParquetFileFragment.__new__(ParquetFileFragment)
         else:
             self = Fragment()
 
@@ -396,11 +432,65 @@ cdef class Fragment:
 
     @property
     def partition_expression(self):
-        """
-        An Expression which evaluates to true for all data viewed by this
+        """An Expression which evaluates to true for all data viewed by this
         Fragment.
         """
         return Expression.wrap(self.fragment.partition_expression())
+
+    def to_table(self, use_threads=True, MemoryPool memory_pool=None):
+        """Convert this Fragment into a Table.
+
+        Use this convenience utility with care. This will serially materialize
+        the Scan result in memory before creating the Table.
+
+        Returns
+        -------
+        table : Table
+        """
+        cdef:
+            shared_ptr[CScanContext] context
+            shared_ptr[CScanOptions] options
+            CScanTaskIterator iterator
+            shared_ptr[CTable] table
+
+        options = self.fragment.scan_options()
+
+        context = make_shared[CScanContext]()
+        context.get().pool = maybe_unbox_memory_pool(memory_pool)
+
+        iterator = move(GetResultValue(self.fragment.Scan(context)))
+        table = GetResultValue(CScanTask.ToTable(options, context,
+                                                 move(iterator)))
+
+        return pyarrow_wrap_table(table)
+
+    def scan(self, MemoryPool memory_pool=None):
+        """Returns a stream of ScanTasks
+
+        The caller is responsible to dispatch/schedule said tasks. Tasks should
+        be safe to run in a concurrent fashion and outlive the iterator.
+
+        Returns
+        -------
+        scan_tasks : iterator of ScanTask
+        """
+        cdef:
+            shared_ptr[CScanContext] context
+            CScanTaskIterator iterator
+            shared_ptr[CScanTask] task
+
+        # create scan context
+        context = make_shared[CScanContext]()
+        context.get().pool = maybe_unbox_memory_pool(memory_pool)
+
+        iterator = move(GetResultValue(self.fragment.Scan(move(context))))
+
+        while True:
+            task = GetResultValue(iterator.Next())
+            if task.get() == nullptr:
+                raise StopIteration()
+            else:
+                yield ScanTask.wrap(task)
 
 
 cdef class FileFragment(Fragment):
@@ -416,9 +506,36 @@ cdef class FileFragment(Fragment):
     @property
     def path(self):
         """
-        The path of the data file viewed by this fragment.
+        The path of the data file viewed by this fragment, if it views a
+        file. If instead it views a buffer, this will be "<Buffer>".
         """
         return frombytes(self.file_fragment.source().path())
+
+    @property
+    def filesystem(self):
+        """
+        The FileSystem containing the data file viewed by this fragment, if
+        it views a file. If instead it views a buffer, this will be None.
+        """
+        cdef:
+            shared_ptr[CFileSystem] fs
+        fs = self.file_fragment.source().filesystem().shared_from_this()
+        return FileSystem.wrap(fs)
+
+    @property
+    def buffer(self):
+        """
+        The buffer viewed by this fragment, if it views a buffer. If
+        instead it views a file, this will be None.
+        """
+        cdef:
+            shared_ptr[CBuffer] c_buffer
+        c_buffer = self.file_fragment.source().buffer()
+
+        if c_buffer.get() == nullptr:
+            return None
+
+        return pyarrow_wrap_buffer(c_buffer)
 
     @property
     def format(self):
@@ -426,6 +543,52 @@ cdef class FileFragment(Fragment):
         The format of the data file viewed by this fragment.
         """
         return FileFormat.wrap(self.file_fragment.format())
+
+
+cdef class ParquetFileFragment(FileFragment):
+    """A Fragment representing a parquet file."""
+
+    cdef:
+        CParquetFileFragment* parquet_file_fragment
+
+    cdef void init(self, const shared_ptr[CFragment]& sp):
+        FileFragment.init(self, sp)
+        self.parquet_file_fragment = <CParquetFileFragment*> sp.get()
+
+    @property
+    def row_groups(self):
+        row_groups = set(self.parquet_file_fragment.row_groups())
+        if len(row_groups) != 0:
+            return row_groups
+        return None
+
+    def get_row_group_fragments(self, Expression extra_filter=None):
+        """
+        Yield a Fragment wrapping each row group in this ParquetFileFragment.
+        Row groups will be excluded whose metadata contradicts the either the
+        filter provided on construction of this Fragment or the extra_filter
+        argument.
+        """
+        cdef:
+            CParquetFileFormat* c_format
+            CFragmentIterator c_iterator
+            shared_ptr[CExpression] c_extra_filter
+            shared_ptr[CFragment] c_fragment
+
+        if extra_filter is None:
+            extra_filter = ScalarExpression(True)
+        c_extra_filter = extra_filter.unwrap()
+
+        c_format = <CParquetFileFormat*> self.file_fragment.format().get()
+        c_iterator = move(GetResultValue(c_format.GetRowGroupFragments(deref(
+            self.parquet_file_fragment), move(c_extra_filter))))
+
+        while True:
+            c_fragment = GetResultValue(c_iterator.Next())
+            if c_fragment.get() == nullptr:
+                raise StopIteration()
+            else:
+                yield Fragment.wrap(c_fragment)
 
 
 cdef class ParquetFileFormatReaderOptions:
@@ -474,13 +637,47 @@ cdef class ParquetFileFormat(FileFormat):
 
     def __init__(self, dict reader_options=dict()):
         self.init(<shared_ptr[CFileFormat]> make_shared[CParquetFileFormat]())
-        self.parquet_format = <CParquetFileFormat*> self.wrapped.get()
         for name, value in reader_options.items():
             setattr(self.reader_options, name, value)
+
+    cdef void init(self, const shared_ptr[CFileFormat]& sp):
+        FileFormat.init(self, sp)
+        self.parquet_format = <CParquetFileFormat*> self.wrapped.get()
 
     @property
     def reader_options(self):
         return ParquetFileFormatReaderOptions(self)
+
+    def make_fragment(self, str path not None, FileSystem filesystem not None,
+                      Schema schema=None, columns=None, filter=None,
+                      Expression partition_expression=ScalarExpression(True),
+                      row_groups=None):
+        cdef:
+            shared_ptr[CScanOptions] c_options
+            shared_ptr[CFileFragment] c_fragment
+            Scanner scanner
+            vector[int] c_row_groups
+
+        if row_groups is None:
+            return super().make_fragment(path, filesystem, schema, columns,
+                                         filter, partition_expression)
+        for row_group in set(row_groups):
+            c_row_groups.push_back(<int> row_group)
+
+        if schema is None:
+            schema = self.inspect(path, filesystem)
+
+        scanner = _empty_dataset_scanner(schema, columns, filter)
+        c_options = scanner.unwrap().get().options()
+
+        c_fragment = GetResultValue(
+            self.parquet_format.MakeFragment(CFileSource(tobytes(path),
+                                                         filesystem.unwrap()
+                                                         .get()),
+                                             move(c_options),
+                                             partition_expression.unwrap(),
+                                             move(c_row_groups)))
+        return Fragment.wrap(<shared_ptr[CFragment]> move(c_fragment))
 
 
 cdef class IpcFileFormat(FileFormat):
@@ -1108,6 +1305,9 @@ cdef class Scanner:
         cdef Scanner self = Scanner.__new__(Scanner)
         self.init(sp)
         return self
+
+    cdef inline shared_ptr[CScanner] unwrap(self):
+        return self.wrapped
 
     def scan(self):
         """Returns a stream of ScanTasks

--- a/python/pyarrow/dataset.py
+++ b/python/pyarrow/dataset.py
@@ -43,6 +43,7 @@ from pyarrow._dataset import (  # noqa
     NotExpression,
     OrExpression,
     ParquetFileFormat,
+    ParquetFileFragment,
     Partitioning,
     PartitioningFactory,
     ScalarExpression,

--- a/python/pyarrow/includes/libarrow_fs.pxd
+++ b/python/pyarrow/includes/libarrow_fs.pxd
@@ -59,6 +59,7 @@ cdef extern from "arrow/filesystem/api.h" namespace "arrow::fs" nogil:
         c_bool recursive
 
     cdef cppclass CFileSystem "arrow::fs::FileSystem":
+        shared_ptr[CFileSystem] shared_from_this()
         c_string type_name() const
         CResult[c_string] NormalizePath(c_string path)
         CResult[CFileInfo] GetFileInfo(const c_string& path)

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -897,6 +897,17 @@ def test_cast_none():
         arr.cast(None)
 
 
+def test_cast_list_to_primitive():
+    # ARROW-8070: cast segfaults on unsupported cast from list<binary> to utf8
+    arr = pa.array([[1, 2], [3, 4]])
+    with pytest.raises(pa.ArrowInvalid):
+        arr.cast(pa.int8())
+
+    arr = pa.array([[b"a", b"b"], [b"c"]], pa.list_(pa.binary()))
+    with pytest.raises(pa.ArrowInvalid):
+        arr.cast(pa.binary())
+
+
 def test_cast_chunked_array():
     arrays = [pa.array([1, 2, 3]), pa.array([4, 5, 6])]
     carr = pa.chunked_array(arrays)

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -85,19 +85,6 @@ def mockfs(request):
 
     mockfs = fs._MockFileSystem()
 
-    data = [
-        list(range(5)),
-        list(map(float, range(5))),
-        list(map(str, range(5)))
-    ]
-    schema = pa.schema([
-        pa.field('i64', pa.int64()),
-        pa.field('f64', pa.float64()),
-        pa.field('str', pa.string())
-    ])
-    batch = pa.record_batch(data, schema=schema)
-    table = pa.Table.from_batches([batch])
-
     directories = [
         'subdir/1/xxx',
         'subdir/2/yyy',
@@ -107,6 +94,21 @@ def mockfs(request):
         path = '{}/file{}.parquet'.format(directory, i)
         mockfs.create_dir(directory)
         with mockfs.open_output_stream(path) as out:
+            data = [
+                list(range(5)),
+                list(map(float, range(5))),
+                list(map(str, range(5))),
+                [i] * 5
+            ]
+            schema = pa.schema([
+                pa.field('i64', pa.int64()),
+                pa.field('f64', pa.float64()),
+                pa.field('str', pa.string()),
+                pa.field('const', pa.int64()),
+            ])
+            batch = pa.record_batch(data, schema=schema)
+            table = pa.Table.from_batches([batch])
+
             pq.write_table(table, out)
 
     return mockfs
@@ -179,7 +181,9 @@ def dataset(mockfs):
 
 
 def test_filesystem_dataset(mockfs):
-    schema = pa.schema([])
+    schema = pa.schema([
+        pa.field('const', pa.int64())
+    ])
 
     file_format = ds.ParquetFileFormat()
 
@@ -225,12 +229,24 @@ def test_filesystem_dataset(mockfs):
     assert set(dataset.files) == set(paths)
 
     fragments = list(dataset.get_fragments())
-    assert fragments[0].partition_expression.equals(
-        ds.AndExpression(root_partition, partitions[0]))
-    assert fragments[1].partition_expression.equals(
-        ds.AndExpression(root_partition, partitions[1]))
-    assert fragments[0].path == paths[0]
-    assert fragments[1].path == paths[1]
+    for fragment, partition, path in zip(fragments, partitions, paths):
+        assert fragment.partition_expression.equals(
+            ds.AndExpression(root_partition, partition))
+        assert fragment.path == path
+        assert isinstance(fragment, ds.ParquetFileFragment)
+        assert fragment.row_groups is None
+
+        row_group_fragments = list(fragment.get_row_group_fragments())
+        assert len(row_group_fragments) == 1
+        assert isinstance(fragment, ds.ParquetFileFragment)
+        assert row_group_fragments[0].path == path
+        assert row_group_fragments[0].row_groups == {0}
+
+    # test predicate pushdown using row group metadata
+    fragments = list(dataset.get_fragments(filter=ds.field("const") == 0))
+    assert len(fragments) == 2
+    assert len(list(fragments[0].get_row_group_fragments())) == 1
+    assert len(list(fragments[1].get_row_group_fragments())) == 0
 
 
 def test_dataset(dataset):
@@ -505,6 +521,7 @@ def test_filesystem_factory(mockfs, paths_or_selector):
         pa.field('i64', pa.int64()),
         pa.field('f64', pa.float64()),
         pa.field('str', pa.dictionary(pa.int32(), pa.string())),
+        pa.field('const', pa.int64()),
         pa.field('group', pa.int32()),
         pa.field('key', pa.string()),
     ]), check_metadata=False)
@@ -525,20 +542,61 @@ def test_filesystem_factory(mockfs, paths_or_selector):
         pa.array([0, 1, 2, 3, 4], type=pa.int32()),
         pa.array("0 1 2 3 4".split(), type=pa.string()))
     for task, group, key in zip(scanner.scan(), [1, 2], ['xxx', 'yyy']):
-        expected_group_column = pa.array([group] * 5, type=pa.int32())
-        expected_key_column = pa.array([key] * 5, type=pa.string())
+        expected_group = pa.array([group] * 5, type=pa.int32())
+        expected_key = pa.array([key] * 5, type=pa.string())
+        expected_const = pa.array([group - 1] * 5, type=pa.int64())
         for batch in task.execute():
-            assert batch.num_columns == 5
+            assert batch.num_columns == 6
             assert batch[0].equals(expected_i64)
             assert batch[1].equals(expected_f64)
             assert batch[2].equals(expected_str)
-            assert batch[3].equals(expected_group_column)
-            assert batch[4].equals(expected_key_column)
+            assert batch[3].equals(expected_const)
+            assert batch[4].equals(expected_group)
+            assert batch[5].equals(expected_key)
 
     table = dataset.to_table()
     assert isinstance(table, pa.Table)
     assert len(table) == 10
-    assert table.num_columns == 5
+    assert table.num_columns == 6
+
+
+def test_make_fragment(multisourcefs):
+    parquet_format = ds.ParquetFileFormat()
+    dataset = ds.dataset('/plain', filesystem=multisourcefs,
+                         format=parquet_format)
+
+    for path in dataset.files:
+        fragment = parquet_format.make_fragment(path, multisourcefs)
+        row_group_fragment = parquet_format.make_fragment(path, multisourcefs,
+                                                          row_groups=[0])
+        for f in [fragment, row_group_fragment]:
+            assert isinstance(f, ds.ParquetFileFragment)
+            assert f.path == path
+            assert isinstance(f.filesystem, type(multisourcefs))
+        assert fragment.row_groups is None
+        assert row_group_fragment.row_groups == {0}
+
+
+def test_parquet_row_group_fragments(tempdir):
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+
+    table = pa.table({'a': ['a', 'a', 'b', 'b'], 'b': [1, 2, 3, 4]})
+    pq.write_to_dataset(table, str(tempdir / "test_parquet_dataset"),
+                        partition_cols=["a"])
+
+    import pyarrow.dataset as ds
+    dataset = ds.dataset(str(tempdir / "test_parquet_dataset/"),
+                         format="parquet", partitioning="hive")
+
+    fragments = list(dataset.get_fragments())
+    f = fragments[0]
+    parquet_format = f.format
+    parquet_format.make_fragment(f.path, f.filesystem,
+                                 partition_expression=f.partition_expression)
+    parquet_format.make_fragment(
+        f.path, f.filesystem, partition_expression=f.partition_expression,
+        row_groups={1})
 
 
 def test_partitioning_factory(mockfs):
@@ -559,6 +617,7 @@ def test_partitioning_factory(mockfs):
         ("i64", pa.int64()),
         ("f64", pa.float64()),
         ("str", pa.string()),
+        ("const", pa.int64()),
         ("group", pa.int32()),
         ("key", pa.string()),
     ])

--- a/rust/arrow/src/ipc/reader.rs
+++ b/rust/arrow/src/ipc/reader.rs
@@ -33,6 +33,8 @@ use crate::ipc;
 use crate::record_batch::{RecordBatch, RecordBatchReader};
 use DataType::*;
 
+const CONTINUATION_MARKER: u32 = 0xffff_ffff;
+
 /// Read a buffer based on offset and length
 fn read_buffer(buf: &ipc::Buffer, a_data: &Vec<u8>) -> Buffer {
     let start_offset = buf.offset() as usize;
@@ -730,6 +732,12 @@ impl<R: Read> StreamReader<R> {
         let mut meta_buffer = vec![0; meta_len as usize];
         reader.read_exact(&mut meta_buffer)?;
 
+        // If a continuation marker is encountered, skip over it and read
+        // the size from the next four bytes.
+        if u32::from_le_bytes(meta_size) == CONTINUATION_MARKER {
+            reader.read_exact(&mut meta_size)?;
+        }
+
         let vecs = &meta_buffer.to_vec();
         let message = ipc::get_root_as_message(vecs);
         // message header is a Schema, so read it
@@ -762,7 +770,18 @@ impl<R: Read> StreamReader<R> {
         // determine metadata length
         let mut meta_size: [u8; 4] = [0; 4];
         self.reader.read_exact(&mut meta_size)?;
-        let meta_len = u32::from_le_bytes(meta_size);
+        let meta_len = {
+            let meta_len = u32::from_le_bytes(meta_size);
+
+            // If a continuation marker is encountered, skip over it and read
+            // the size from the next four bytes.
+            if meta_len == CONTINUATION_MARKER {
+                self.reader.read_exact(&mut meta_size)?;
+                u32::from_le_bytes(meta_size)
+            } else {
+                meta_len
+            }
+        };
 
         if meta_len == 0 {
             // the stream has ended, mark the reader as finished

--- a/rust/datafusion/src/logicalplan.rs
+++ b/rust/datafusion/src/logicalplan.rs
@@ -841,8 +841,8 @@ mod tests {
         .build()?;
 
         let expected = "Projection: #0, #1 AS total_salary\
-        \n  Aggregate: groupBy=[[#0]], aggr=[[SUM(#1)]]\
-        \n    TableScan: employee.csv projection=Some([3, 4])";
+                        \n  Aggregate: groupBy=[[#0]], aggr=[[SUM(#1)]]\
+                        \n    TableScan: employee.csv projection=Some([3, 4])";
 
         assert_eq!(expected, format!("{:?}", plan));
 

--- a/rust/datafusion/src/optimizer/projection_push_down.rs
+++ b/rust/datafusion/src/optimizer/projection_push_down.rs
@@ -58,7 +58,7 @@ impl ProjectionPushDown {
                 schema,
             } => {
                 // collect all columns referenced by projection expressions
-                utils::exprlist_to_column_indices(&expr, accum);
+                utils::exprlist_to_column_indices(&expr, accum)?;
 
                 // push projection down
                 let input = self.optimize_plan(&input, accum, mapping)?;
@@ -74,7 +74,7 @@ impl ProjectionPushDown {
             }
             LogicalPlan::Selection { expr, input } => {
                 // collect all columns referenced by filter expression
-                utils::expr_to_column_indices(expr, accum);
+                utils::expr_to_column_indices(expr, accum)?;
 
                 // push projection down
                 let input = self.optimize_plan(&input, accum, mapping)?;
@@ -94,8 +94,8 @@ impl ProjectionPushDown {
                 schema,
             } => {
                 // collect all columns referenced by grouping and aggregate expressions
-                utils::exprlist_to_column_indices(&group_expr, accum);
-                utils::exprlist_to_column_indices(&aggr_expr, accum);
+                utils::exprlist_to_column_indices(&group_expr, accum)?;
+                utils::exprlist_to_column_indices(&aggr_expr, accum)?;
 
                 // push projection down
                 let input = self.optimize_plan(&input, accum, mapping)?;
@@ -117,7 +117,7 @@ impl ProjectionPushDown {
                 schema,
             } => {
                 // collect all columns referenced by sort expressions
-                utils::exprlist_to_column_indices(&expr, accum);
+                utils::exprlist_to_column_indices(&expr, accum)?;
 
                 // push projection down
                 let input = self.optimize_plan(&input, accum, mapping)?;
@@ -271,6 +271,9 @@ impl ProjectionPushDown {
                 args: self.rewrite_exprs(args, mapping)?,
                 return_type: return_type.clone(),
             }),
+            Expr::Wildcard => Err(ExecutionError::General(
+                "Wildcard expressions are not valid in a logical query plan".to_owned(),
+            )),
         }
     }
 

--- a/rust/datafusion/src/optimizer/type_coercion.rs
+++ b/rust/datafusion/src/optimizer/type_coercion.rs
@@ -96,8 +96,8 @@ fn rewrite_expr(expr: &Expr, schema: &Schema) -> Result<Expr> {
         Expr::BinaryExpr { left, op, right } => {
             let left = rewrite_expr(left, schema)?;
             let right = rewrite_expr(right, schema)?;
-            let left_type = left.get_type(schema);
-            let right_type = right.get_type(schema);
+            let left_type = left.get_type(schema)?;
+            let right_type = right.get_type(schema)?;
             if left_type == right_type {
                 Ok(Expr::BinaryExpr {
                     left: Arc::new(left),

--- a/rust/datafusion/src/optimizer/utils.rs
+++ b/rust/datafusion/src/optimizer/utils.rs
@@ -26,30 +26,44 @@ use crate::logicalplan::Expr;
 
 /// Recursively walk a list of expression trees, collecting the unique set of column
 /// indexes referenced in the expression
-pub fn exprlist_to_column_indices(expr: &Vec<Expr>, accum: &mut HashSet<usize>) {
-    expr.iter().for_each(|e| expr_to_column_indices(e, accum));
+pub fn exprlist_to_column_indices(
+    expr: &Vec<Expr>,
+    accum: &mut HashSet<usize>,
+) -> Result<()> {
+    for e in expr {
+        expr_to_column_indices(e, accum)?;
+    }
+    Ok(())
 }
 
 /// Recursively walk an expression tree, collecting the unique set of column indexes
 /// referenced in the expression
-pub fn expr_to_column_indices(expr: &Expr, accum: &mut HashSet<usize>) {
+pub fn expr_to_column_indices(expr: &Expr, accum: &mut HashSet<usize>) -> Result<()> {
     match expr {
         Expr::Alias(expr, _) => expr_to_column_indices(expr, accum),
         Expr::Column(i) => {
             accum.insert(*i);
+            Ok(())
         }
-        Expr::Literal(_) => { /* not needed */ }
+        Expr::Literal(_) => {
+            // not needed
+            Ok(())
+        }
         Expr::Not(e) => expr_to_column_indices(e, accum),
         Expr::IsNull(e) => expr_to_column_indices(e, accum),
         Expr::IsNotNull(e) => expr_to_column_indices(e, accum),
         Expr::BinaryExpr { left, right, .. } => {
-            expr_to_column_indices(left, accum);
-            expr_to_column_indices(right, accum);
+            expr_to_column_indices(left, accum)?;
+            expr_to_column_indices(right, accum)?;
+            Ok(())
         }
         Expr::Cast { expr, .. } => expr_to_column_indices(expr, accum),
         Expr::Sort { expr, .. } => expr_to_column_indices(expr, accum),
         Expr::AggregateFunction { args, .. } => exprlist_to_column_indices(args, accum),
         Expr::ScalarFunction { args, .. } => exprlist_to_column_indices(args, accum),
+        Expr::Wildcard => Err(ExecutionError::General(
+            "Wildcard expressions are not valid in a logical query plan".to_owned(),
+        )),
     }
 }
 
@@ -57,7 +71,7 @@ pub fn expr_to_column_indices(expr: &Expr, accum: &mut HashSet<usize>) {
 pub fn expr_to_field(e: &Expr, input_schema: &Schema) -> Result<Field> {
     match e {
         Expr::Alias(expr, name) => {
-            Ok(Field::new(name, expr.get_type(input_schema), true))
+            Ok(Field::new(name, expr.get_type(input_schema)?, true))
         }
         Expr::Column(i) => {
             let input_schema_field_count = input_schema.fields().len();
@@ -89,8 +103,8 @@ pub fn expr_to_field(e: &Expr, input_schema: &Schema) -> Result<Field> {
             ref right,
             ..
         } => {
-            let left_type = left.get_type(input_schema);
-            let right_type = right.get_type(input_schema);
+            let left_type = left.get_type(input_schema)?;
+            let right_type = right.get_type(input_schema)?;
             Ok(Field::new(
                 "binary_expr",
                 get_supertype(&left_type, &right_type).unwrap(),
@@ -235,7 +249,7 @@ mod tests {
     use std::sync::Arc;
 
     #[test]
-    fn test_collect_expr() {
+    fn test_collect_expr() -> Result<()> {
         let mut accum: HashSet<usize> = HashSet::new();
         expr_to_column_indices(
             &Expr::Cast {
@@ -243,15 +257,16 @@ mod tests {
                 data_type: DataType::Float64,
             },
             &mut accum,
-        );
+        )?;
         expr_to_column_indices(
             &Expr::Cast {
                 expr: Arc::new(Expr::Column(3)),
                 data_type: DataType::Float64,
             },
             &mut accum,
-        );
+        )?;
         assert_eq!(1, accum.len());
         assert!(accum.contains(&3));
+        Ok(())
     }
 }

--- a/rust/datafusion/src/sql/planner.rs
+++ b/rust/datafusion/src/sql/planner.rs
@@ -272,9 +272,10 @@ impl<S: SchemaProvider> SqlToRel<S> {
                 Ok(Expr::Literal(ScalarValue::Utf8(s.clone())))
             }
 
-            ASTNode::SQLAliasedExpr(ref expr, ref alias) => {
-                Ok(Alias(Arc::new(self.sql_to_rex(&expr, schema)?), alias.to_owned()))
-            }
+            ASTNode::SQLAliasedExpr(ref expr, ref alias) => Ok(Alias(
+                Arc::new(self.sql_to_rex(&expr, schema)?),
+                alias.to_owned(),
+            )),
 
             ASTNode::SQLIdentifier(ref id) => {
                 match schema.fields().iter().position(|c| c.name().eq(id)) {
@@ -610,7 +611,7 @@ mod tests {
     fn select_aliased_scalar_func() {
         let sql = "SELECT sqrt(age) AS square_people FROM person";
         let expected = "Projection: sqrt(CAST(#3 AS Float64)) AS square_people\
-        \n  TableScan: person projection=None";
+                        \n  TableScan: person projection=None";
         quick_test(sql, expected);
     }
 


### PR DESCRIPTION
Amazon EC2 vs S3
```
------------------------------------------------------------------------------------------------
Benchmark                                                         Time           CPU Iterations
------------------------------------------------------------------------------------------------
MinioFixture/ReadParquet250K/real_time                   3838190732 ns 1432626296 ns         25   56.6316MB/s   0.260539 items/s
MinioFixture/ReadParquet250KSelection/real_time          2881196274 ns 1123111214 ns         26   75.4419MB/s   0.347078 items/s
MinioFixture/ReadCoalescedParquet250K/real_time          2810860217 ns  284785480 ns         32   77.3296MB/s   0.355763 items/s
MinioFixture/ReadCoalescedParquet250KSelection/real_time 5429450225 ns  211189545 ns         31    40.034MB/s   0.184181 items/s
(arrow) ubuntu@ip-172-31-0-132:~/arrow/build$ cat baseline.log 
----------------------------------------------------------------------------
Benchmark                                     Time           CPU Iterations
----------------------------------------------------------------------------
MinioFixture/ReadAll1Mib/real_time     31786809 ns    5286021 ns        684   31.4596MB/s    31.4596 items/s
MinioFixture/ReadAll100Mib/real_time 1318736153 ns  512591940 ns         16   75.8302MB/s   0.758302 items/s
MinioFixture/ReadAll500Mib/real_time 7587083444 ns 2746296775 ns          3   65.9015MB/s   0.131803 items/s

    time_namelookup:  0.004236s
       time_connect:  0.004504s
    time_appconnect:  0.014875s
   time_pretransfer:  0.014910s
      time_redirect:  0.000000s
 time_starttransfer:  0.017574s
                    ----------
         time_total:  0.017642s
```
I believe given the test setup, that the naive strategy is already doing the optimal thing. (15ms connection latency, 75 MB/s bandwidth = a new connection for anything over 1.125 MB is worthwhile, and the column chunks here are about 2 MB each.)

Local, Minio, 20±2ms latency injected
```
------------------------------------------------------------------------------------------------
Benchmark                                                         Time           CPU Iterations
------------------------------------------------------------------------------------------------
MinioFixture/ReadParquet250K/real_time                   3090663496 ns  697208869 ns         12   70.3288MB/s   0.323555 items/s
MinioFixture/ReadParquet250KSelection/real_time          2297275612 ns  508295811 ns         18   94.6176MB/s   0.435298 items/s
MinioFixture/ReadCoalescedParquet250K/real_time           584935812 ns  169716541 ns         70   371.601MB/s    1.70959 items/s
MinioFixture/ReadCoalescedParquet250KSelection/real_time  470925798 ns  129305911 ns         88   461.565MB/s    2.12348 items/s
```