### PR TITLE
Improve coalesce performance

### DIFF
--- a/cpp/src/arrow/compute/kernels/scalar_if_else.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else.cc
@@ -15,24 +15,26 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <arrow/array/builder_nested.h>
-#include <arrow/array/builder_primitive.h>
-#include <arrow/array/builder_time.h>
-#include <arrow/array/builder_union.h>
-#include <arrow/compute/api.h>
-#include <arrow/compute/kernels/codegen_internal.h>
-#include <arrow/compute/util_internal.h>
-#include <arrow/util/bit_block_counter.h>
-#include <arrow/util/bit_run_reader.h>
-#include <arrow/util/bitmap.h>
-#include <arrow/util/bitmap_ops.h>
-#include <arrow/util/bitmap_reader.h>
+#include "arrow/array/builder_nested.h"
+#include "arrow/array/builder_primitive.h"
+#include "arrow/array/builder_time.h"
+#include "arrow/array/builder_union.h"
+#include "arrow/compute/api.h"
+#include "arrow/compute/kernels/codegen_internal.h"
+#include "arrow/compute/util_internal.h"
+#include "arrow/util/bit_block_counter.h"
+#include "arrow/util/bit_run_reader.h"
+#include "arrow/util/bitmap.h"
+#include "arrow/util/bitmap_ops.h"
+#include "arrow/util/bitmap_reader.h"
 
 namespace arrow {
+
 using internal::BitBlockCount;
 using internal::BitBlockCounter;
 using internal::Bitmap;
 using internal::BitmapWordReader;
+using internal::BitRunReader;
 
 namespace compute {
 namespace internal {
@@ -1072,6 +1074,7 @@ struct CopyFixedWidth<BooleanType> {
     arrow::internal::CopyBitmap(in_values, in_offset, length, raw_out_values, out_offset);
   }
 };
+
 template <typename Type>
 struct CopyFixedWidth<Type, enable_if_number<Type>> {
   using CType = typename TypeTraits<Type>::CType;
@@ -1088,6 +1091,7 @@ struct CopyFixedWidth<Type, enable_if_number<Type>> {
                 in_values + in_offset * sizeof(CType), length * sizeof(CType));
   }
 };
+
 template <typename Type>
 struct CopyFixedWidth<Type, enable_if_same<Type, FixedSizeBinaryType>> {
   static void CopyScalar(const Scalar& values, const int64_t length,
@@ -1115,6 +1119,7 @@ struct CopyFixedWidth<Type, enable_if_same<Type, FixedSizeBinaryType>> {
     std::memcpy(next, in_values + in_offset * width, length * width);
   }
 };
+
 template <typename Type>
 struct CopyFixedWidth<Type, enable_if_decimal<Type>> {
   using ScalarType = typename TypeTraits<Type>::ScalarType;
@@ -1138,6 +1143,7 @@ struct CopyFixedWidth<Type, enable_if_decimal<Type>> {
     std::memcpy(next, in_values + in_offset * width, length * width);
   }
 };
+
 // Copy fixed-width values from a scalar/array datum into an output values buffer
 template <typename Type>
 void CopyValues(const Datum& in_values, const int64_t in_offset, const int64_t length,
@@ -1726,54 +1732,45 @@ Status ExecScalarCoalesce(KernelContext* ctx, const ExecBatch& batch, Datum* out
 template <typename Type>
 void CopyValuesAllValid(Datum source, uint8_t* out_valid, uint8_t* out_values,
                         const int64_t out_offset, const int64_t length) {
-  BitBlockCounter counter(out_valid, out_offset, length);
+  BitRunReader bit_reader(out_valid, out_offset, length);
   int64_t offset = 0;
-  while (offset < length) {
-    const auto block = counter.NextWord();
-    if (block.NoneSet()) {
-      CopyValues<Type>(source, offset, block.length, out_valid, out_values,
-                       out_offset + offset);
-    } else if (!block.AllSet()) {
-      for (int64_t j = 0; j < block.length; ++j) {
-        if (!BitUtil::GetBit(out_valid, out_offset + offset + j)) {
-          CopyValues<Type>(source, offset + j, 1, out_valid, out_values,
-                           out_offset + offset + j);
-        }
-      }
+  while (true) {
+    const auto run = bit_reader.NextRun();
+    if (run.length == 0) {
+      break;
     }
-    offset += block.length;
+    if (!run.set) {
+      CopyValues<Type>(source, offset, run.length, out_valid, out_values,
+                       out_offset + offset);
+    }
+    offset += run.length;
   }
+  DCHECK_EQ(offset, length);
 }
 
 // Helper: zero the values buffer of the output wherever the slot is null
 void InitializeNullSlots(const DataType& type, uint8_t* out_valid, uint8_t* out_values,
                          const int64_t out_offset, const int64_t length) {
-  BitBlockCounter counter(out_valid, out_offset, length);
+  BitRunReader bit_reader(out_valid, out_offset, length);
   int64_t offset = 0;
-  auto bit_width = checked_cast<const FixedWidthType&>(type).bit_width();
-  auto byte_width = BitUtil::BytesForBits(bit_width);
-  while (offset < length) {
-    const auto block = counter.NextWord();
-    if (block.NoneSet()) {
+  const auto bit_width = checked_cast<const FixedWidthType&>(type).bit_width();
+  const auto byte_width = BitUtil::BytesForBits(bit_width);
+  while (true) {
+    const auto run = bit_reader.NextRun();
+    if (run.length == 0) {
+      break;
+    }
+    if (!run.set) {
       if (bit_width == 1) {
-        BitUtil::SetBitsTo(out_values, out_offset + offset, block.length, false);
+        BitUtil::SetBitsTo(out_values, out_offset + offset, run.length, false);
       } else {
-        std::memset(out_values + (out_offset + offset) * byte_width, 0x00,
-                    byte_width * block.length);
-      }
-    } else if (!block.AllSet()) {
-      for (int64_t j = 0; j < block.length; ++j) {
-        if (BitUtil::GetBit(out_valid, out_offset + offset + j)) continue;
-        if (bit_width == 1) {
-          BitUtil::ClearBit(out_values, out_offset + offset + j);
-        } else {
-          std::memset(out_values + (out_offset + offset + j) * byte_width, 0x00,
-                      byte_width);
-        }
+        std::memset(out_values + (out_offset + offset) * byte_width, 0,
+                    byte_width * run.length);
       }
     }
-    offset += block.length;
+    offset += run.length;
   }
+  DCHECK_EQ(offset, length);
 }
 
 // Implement 'coalesce' for any mix of scalar/array arguments for any fixed-width type
@@ -1783,42 +1780,68 @@ Status ExecArrayCoalesce(KernelContext* ctx, const ExecBatch& batch, Datum* out)
   const int64_t out_offset = output->offset;
   // Use output validity buffer as mask to decide what values to copy
   uint8_t* out_valid = output->buffers[0]->mutable_data();
-  // Clear output buffer - no values are set initially
+
+  // Clear output validity buffer - no values are set initially
   BitUtil::SetBitsTo(out_valid, out_offset, batch.length, false);
   uint8_t* out_values = output->buffers[1]->mutable_data();
 
   for (const auto& datum : batch.values) {
-    if ((datum.is_scalar() && datum.scalar()->is_valid) ||
-        (datum.is_array() && !datum.array()->MayHaveNulls())) {
+    if (datum.null_count() == 0) {
       // Valid scalar, or all-valid array
       CopyValuesAllValid<Type>(datum, out_valid, out_values, out_offset, batch.length);
       break;
     } else if (datum.is_array()) {
       // Array with nulls
       const ArrayData& arr = *datum.array();
-      const DataType& type = *datum.type();
+      const int64_t in_offset = arr.offset;
+      const int64_t in_null_count = arr.null_count;
+      DCHECK_GT(in_null_count, 0);  // computed in datum.null_count()
+      const DataType& type = *arr.type;
       const uint8_t* in_valid = arr.buffers[0]->data();
       const uint8_t* in_values = arr.buffers[1]->data();
-      BinaryBitBlockCounter counter(in_valid, arr.offset, out_valid, out_offset,
-                                    batch.length);
-      int64_t offset = 0;
-      while (offset < batch.length) {
-        const auto block = counter.NextAndNotWord();
-        if (block.AllSet()) {
-          CopyValues<Type>(datum, offset, block.length, out_valid, out_values,
-                           out_offset + offset);
-        } else if (block.popcount) {
-          for (int64_t j = 0; j < block.length; ++j) {
-            if (!BitUtil::GetBit(out_valid, out_offset + offset + j) &&
-                BitUtil::GetBit(in_valid, arr.offset + offset + j)) {
-              // This version lets us avoid calling MayHaveNulls() on every iteration
-              // (which does an atomic load and can add up)
-              CopyOneArrayValue<Type>(type, in_valid, in_values, arr.offset + offset + j,
-                                      out_valid, out_values, out_offset + offset + j);
+
+      if (in_null_count < 0.8 * batch.length) {
+        // The input is not mostly null, we deem it more efficient to
+        // copy values even underlying null slots instead of the more
+        // expensive bitmasking using BinaryBitBlockCounter.
+        BitRunReader bit_reader(out_valid, out_offset, batch.length);
+        int64_t offset = 0;
+        while (true) {
+          const auto run = bit_reader.NextRun();
+          if (run.length == 0) {
+            break;
+          }
+          if (!run.set) {
+            // Copy from input
+            CopyFixedWidth<Type>::CopyArray(type, in_values, in_offset + offset,
+                                            run.length, out_values, out_offset + offset);
+          }
+          offset += run.length;
+        }
+        arrow::internal::BitmapOr(out_valid, out_offset, in_valid, in_offset,
+                                  batch.length, out_offset, out_valid);
+      } else {
+        BinaryBitBlockCounter counter(in_valid, in_offset, out_valid, out_offset,
+                                      batch.length);
+        int64_t offset = 0;
+        while (offset < batch.length) {
+          const auto block = counter.NextAndNotWord();
+          if (block.AllSet()) {
+            CopyValues<Type>(datum, offset, block.length, out_valid, out_values,
+                             out_offset + offset);
+          } else if (block.popcount) {
+            for (int64_t j = 0; j < block.length; ++j) {
+              if (!BitUtil::GetBit(out_valid, out_offset + offset + j) &&
+                  BitUtil::GetBit(in_valid, in_offset + offset + j)) {
+                // This version lets us avoid calling MayHaveNulls() on every iteration
+                // (which does an atomic load and can add up)
+                CopyOneArrayValue<Type>(type, in_valid, in_values, in_offset + offset + j,
+                                        out_valid, out_values, out_offset + offset + j);
+              }
             }
           }
+          offset += block.length;
         }
-        offset += block.length;
       }
     }
   }
@@ -1843,22 +1866,44 @@ Status ExecArrayScalarCoalesce(KernelContext* ctx, Datum left, Datum right,
   const uint8_t* left_values = left_arr.buffers[1]->data();
   const Scalar& right_scalar = *right.scalar();
 
-  arrow::internal::BitRunReader reader(left_valid, left_arr.offset, left_arr.length);
-  int64_t offset = 0;
-  while (true) {
-    const auto run = reader.NextRun();
-    if (run.length == 0) break;
-    if (run.set) {
-      // All from left
-      CopyFixedWidth<Type>::CopyArray(*left_arr.type, left_values,
-                                      left_arr.offset + offset, run.length, out_values,
-                                      out_offset + offset);
-    } else {
-      // All from right
-      CopyFixedWidth<Type>::CopyScalar(right_scalar, run.length, out_values,
-                                       out_offset + offset);
+  if (left.null_count() < length * 0.2) {
+    // There are less than 20% nulls in the left array, so first copy
+    // the left values, then fill any nulls with the right value
+    CopyFixedWidth<Type>::CopyArray(*left_arr.type, left_values, left_arr.offset, length,
+                                    out_values, out_offset);
+
+    BitRunReader reader(left_valid, left_arr.offset, left_arr.length);
+    int64_t offset = 0;
+    while (true) {
+      const auto run = reader.NextRun();
+      if (run.length == 0) break;
+      if (!run.set) {
+        // All from right
+        CopyFixedWidth<Type>::CopyScalar(right_scalar, run.length, out_values,
+                                         out_offset + offset);
+      }
+      offset += run.length;
     }
-    offset += run.length;
+    DCHECK_EQ(offset, length);
+  } else {
+    BitRunReader reader(left_valid, left_arr.offset, left_arr.length);
+    int64_t offset = 0;
+    while (true) {
+      const auto run = reader.NextRun();
+      if (run.length == 0) break;
+      if (run.set) {
+        // All from left
+        CopyFixedWidth<Type>::CopyArray(*left_arr.type, left_values,
+                                        left_arr.offset + offset, run.length, out_values,
+                                        out_offset + offset);
+      } else {
+        // All from right
+        CopyFixedWidth<Type>::CopyScalar(right_scalar, run.length, out_values,
+                                         out_offset + offset);
+      }
+      offset += run.length;
+    }
+    DCHECK_EQ(offset, length);
   }
 
   if (right_scalar.is_valid || !left_valid) {
@@ -1885,12 +1930,16 @@ Status ExecBinaryCoalesce(KernelContext* ctx, Datum left, Datum right, int64_t l
   const int64_t out_offset = output->offset;
   uint8_t* out_valid = output->buffers[0]->mutable_data();
   uint8_t* out_values = output->buffers[1]->mutable_data();
+
+  const int64_t left_null_count = left.null_count();
+  const int64_t right_null_count = right.null_count();
+
   if (left.is_scalar()) {
     // (Scalar, Any)
     CopyValues<Type>(left.scalar()->is_valid ? left : right, /*in_offset=*/0, length,
                      out_valid, out_values, out_offset);
     return Status::OK();
-  } else if (left.null_count() == 0) {
+  } else if (left_null_count == 0) {
     // LHS is array without nulls. Must copy (since we preallocate)
     CopyValues<Type>(left, /*in_offset=*/0, length, out_valid, out_values, out_offset);
     return Status::OK();
@@ -1901,32 +1950,40 @@ Status ExecBinaryCoalesce(KernelContext* ctx, Datum left, Datum right, int64_t l
 
   // (Array, Array)
   const ArrayData& left_arr = *left.array();
+  const ArrayData& right_arr = *right.array();
   const uint8_t* left_valid = left_arr.buffers[0]->data();
-  BitBlockCounter bit_counter(left_valid, left_arr.offset, left_arr.length);
+  const uint8_t* left_values = left_arr.buffers[1]->data();
+  const uint8_t* right_valid =
+      right_null_count > 0 ? right_arr.buffers[0]->data() : nullptr;
+  const uint8_t* right_values = right_arr.buffers[1]->data();
+
+  BitRunReader bit_reader(left_valid, left_arr.offset, left_arr.length);
   int64_t offset = 0;
-  while (offset < length) {
-    const auto block = bit_counter.NextWord();
-    if (block.AllSet()) {
-      // All from left
-      CopyValues<Type>(left, offset, block.length, out_valid, out_values,
-                       out_offset + offset);
-    } else if (block.NoneSet()) {
-      // All from right
-      CopyValues<Type>(right, offset, block.length, out_valid, out_values,
-                       out_offset + offset);
-    } else if (block.popcount) {
-      // One by one
-      for (int64_t j = 0; j < block.length; ++j) {
-        if (BitUtil::GetBit(left_valid, left_arr.offset + offset + j)) {
-          CopyOneValue<Type>(left, offset + j, out_valid, out_values,
-                             out_offset + offset + j);
-        } else {
-          CopyOneValue<Type>(right, offset + j, out_valid, out_values,
-                             out_offset + offset + j);
-        }
-      }
+  while (true) {
+    const auto run = bit_reader.NextRun();
+    if (run.length == 0) {
+      break;
     }
-    offset += block.length;
+    if (run.set) {
+      // All from left
+      CopyFixedWidth<Type>::CopyArray(*left_arr.type, left_values,
+                                      left_arr.offset + offset, run.length, out_values,
+                                      out_offset + offset);
+    } else {
+      // All from right
+      CopyFixedWidth<Type>::CopyArray(*right_arr.type, right_values,
+                                      right_arr.offset + offset, run.length, out_values,
+                                      out_offset + offset);
+    }
+    offset += run.length;
+  }
+  DCHECK_EQ(offset, length);
+
+  if (right_null_count == 0) {
+    BitUtil::SetBitsTo(out_valid, out_offset, length, true);
+  } else {
+    arrow::internal::BitmapOr(left_valid, left_arr.offset, right_valid, right_arr.offset,
+                              length, out_offset, out_valid);
   }
   return Status::OK();
 }


### PR DESCRIPTION
Before:
```
--------------------------------------------------------------------------------------
Benchmark                            Time             CPU   Iterations UserCounters...
--------------------------------------------------------------------------------------
CoalesceBench64/0              3366683 ns      3364669 ns          213 bytes_per_second=2.32192G/s items_per_second=311.643M/s length=1048.58k null%=1 num_args=2
CoalesceBench64/1              2851663 ns      2849846 ns          245 bytes_per_second=2.74138G/s items_per_second=367.941M/s length=1048.58k null%=1 num_args=4
CoalesceBench64/2              7499865 ns      7495813 ns           95 bytes_per_second=1067.26M/s items_per_second=139.888M/s length=1048.58k null%=25 num_args=2
CoalesceBench64/3             11773437 ns     11766272 ns           60 bytes_per_second=679.909M/s items_per_second=89.1171M/s length=1048.58k null%=25 num_args=4
CoalesceBench64/4              9636207 ns      9631169 ns           73 bytes_per_second=830.636M/s items_per_second=108.873M/s length=1048.58k null%=50 num_args=2
CoalesceBench64/5             19456855 ns     19445858 ns           36 bytes_per_second=411.399M/s items_per_second=53.9228M/s length=1048.58k null%=50 num_args=4
CoalesceBench64/6              3288217 ns      3286426 ns          214 bytes_per_second=2.3772G/s items_per_second=319.063M/s length=1048.58k null%=99 num_args=2
CoalesceBench64/7              7603232 ns      7599720 ns           92 bytes_per_second=1052.67M/s items_per_second=137.976M/s length=1048.58k null%=99 num_args=4
CoalesceScalarBench64/0         775260 ns       774797 ns          904 bytes_per_second=10.0833G/s items_per_second=1.35336G/s length=1048.58k null%=1 num_args=2
CoalesceScalarBench64/2        3500267 ns      3498388 ns          201 bytes_per_second=2.23317G/s items_per_second=299.731M/s length=1048.58k null%=25 num_args=2
CoalesceScalarBench64/4        4815186 ns      4812821 ns          146 bytes_per_second=1.62327G/s items_per_second=217.871M/s length=1048.58k null%=50 num_args=2
CoalesceScalarBench64/6         446897 ns       446783 ns         1541 bytes_per_second=17.4861G/s items_per_second=2.34695G/s length=1048.58k null%=99 num_args=2
CoalesceScalarStringBench/0   74138532 ns     74089097 ns           10 bytes_per_second=6.72872G/s items_per_second=14.1529M/s length=1048.58k null%=1 num_args=2
CoalesceScalarStringBench/2   58106933 ns     58064020 ns            9 bytes_per_second=6.52407G/s items_per_second=18.059M/s length=1048.58k null%=25 num_args=2
CoalesceScalarStringBench/4   52094990 ns     52064312 ns           10 bytes_per_second=4.88432G/s items_per_second=20.14M/s length=1048.58k null%=50 num_args=2
CoalesceScalarStringBench/6    5136540 ns      5133121 ns          138 bytes_per_second=1.7244G/s items_per_second=204.276M/s length=1048.58k null%=99 num_args=2
```

After:
```
--------------------------------------------------------------------------------------
Benchmark                            Time             CPU   Iterations UserCounters...
--------------------------------------------------------------------------------------
CoalesceBench64/0              1047061 ns      1046399 ns          661 bytes_per_second=7.46608G/s items_per_second=1002.08M/s length=1048.58k null%=1 num_args=2
CoalesceBench64/1              1377282 ns      1376405 ns          511 bytes_per_second=5.67602G/s items_per_second=761.822M/s length=1048.58k null%=1 num_args=4
CoalesceBench64/2              2804061 ns      2802178 ns          251 bytes_per_second=2.78801G/s items_per_second=374.2M/s length=1048.58k null%=25 num_args=2
CoalesceBench64/3              5234633 ns      5230898 ns          134 bytes_per_second=1.49353G/s items_per_second=200.458M/s length=1048.58k null%=25 num_args=4
CoalesceBench64/4              3700820 ns      3698116 ns          190 bytes_per_second=2.11256G/s items_per_second=283.543M/s length=1048.58k null%=50 num_args=2
CoalesceBench64/5              7731316 ns      7726379 ns           90 bytes_per_second=1035.41M/s items_per_second=135.714M/s length=1048.58k null%=50 num_args=4
CoalesceBench64/6              1004359 ns      1003745 ns          693 bytes_per_second=7.78335G/s items_per_second=1044.66M/s length=1048.58k null%=99 num_args=2
CoalesceBench64/7              4660379 ns      4658001 ns          151 bytes_per_second=1.67722G/s items_per_second=225.113M/s length=1048.58k null%=99 num_args=4
CoalesceScalarBench64/0         656265 ns       655870 ns         1067 bytes_per_second=11.9117G/s items_per_second=1.59876G/s length=1048.58k null%=1 num_args=2
CoalesceScalarBench64/2        2889294 ns      2887898 ns          242 bytes_per_second=2.70525G/s items_per_second=363.093M/s length=1048.58k null%=25 num_args=2
CoalesceScalarBench64/4        4015990 ns      4014054 ns          175 bytes_per_second=1.94629G/s items_per_second=261.226M/s length=1048.58k null%=50 num_args=2
CoalesceScalarBench64/6         390245 ns       390138 ns         1800 bytes_per_second=20.025G/s items_per_second=2.68771G/s length=1048.58k null%=99 num_args=2
CoalesceScalarStringBench/0   82277097 ns     82223643 ns            9 bytes_per_second=6.06303G/s items_per_second=12.7527M/s length=1048.58k null%=1 num_args=2
CoalesceScalarStringBench/2   70821126 ns     70771323 ns           10 bytes_per_second=5.35265G/s items_per_second=14.8164M/s length=1048.58k null%=25 num_args=2
CoalesceScalarStringBench/4   47119447 ns     47087724 ns           13 bytes_per_second=5.40053G/s items_per_second=22.2686M/s length=1048.58k null%=50 num_args=2
CoalesceScalarStringBench/6    4579486 ns      4576728 ns          150 bytes_per_second=1.93403G/s items_per_second=229.11M/s length=1048.58k null%=99 num_args=2
```